### PR TITLE
Klikbare videofragmenten in de presentaties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "@slidev/cli": "^52.15.2",
         "@slidev/theme-default": "^0.25.0",
         "mdast-util-mdx-jsx": "^3.2.0",
-        "unist-util-visit": "^5.1.0"
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -14334,9 +14335,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "astro dev",
     "build:site": "astro build",
-    "build:slides": "node slides/build-all.mjs",
+    "sync:videos": "node slides/sync-videos.mjs",
+    "build:slides": "npm run sync:videos && node slides/build-all.mjs",
     "build": "npm run build:site && npm run build:slides",
     "preview": "astro preview",
     "astro": "astro"
@@ -34,6 +35,7 @@
     "@slidev/cli": "^52.15.2",
     "@slidev/theme-default": "^0.25.0",
     "mdast-util-mdx-jsx": "^3.2.0",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/slides/inleiding/slides.md
+++ b/slides/inleiding/slides.md
@@ -442,7 +442,7 @@ layout: quadrants
 
 de lijn die je meeneuriet
 
-→ Beethoven, 9e symfonie
+<CourseVideo id="inleiding/beethoven" label="Beethoven, 5e symfonie" />
 
 ::q2::
 
@@ -450,7 +450,7 @@ de lijn die je meeneuriet
 
 organisatie van tijd
 
-→ Strawinsky, Le Sacre du Printemps
+<CourseVideo id="inleiding/stravinsky" label="Strawinsky, Le Sacre du Printemps" />
 
 ::q3::
 
@@ -466,7 +466,9 @@ fluisteren ↔ schreeuwen
 
 de huid van het geluid
 
-→ Holiday vs O'Connor
+<CourseVideo id="inleiding/holiday" label="Holiday, Strange Fruit" />
+
+<CourseVideo id="inleiding/troy" label="O'Connor, Troy" />
 
 <!--
 Hier laat je fragmenten horen — de eerste vier noten van Beethovens 5e (melodie als

--- a/slides/sync-videos.mjs
+++ b/slides/sync-videos.mjs
@@ -1,0 +1,52 @@
+// Leest de `videos:`-map uit de frontmatter van elk hoofdstuk en schrijft die
+// naar één JSON-bestand in de gedeelde Slidev-addon. Zo staat de timing van een
+// fragment op één plaats — in de cursustekst — en gebruiken de decks dezelfde
+// waarden zonder dat de slidebuild de Astro-contentcollectie hoeft te kennen.
+//
+// Het gegenereerde bestand gaat mee in git, zodat `slidev dev` werkt zonder
+// eerst een build te draaien. Draai `npm run sync:videos` na het wijzigen van
+// een `videos:`-blok; `npm run build:slides` doet het automatisch.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const slidesDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(slidesDir, '..');
+const themesDir = join(projectRoot, 'src', 'content', 'themes');
+const outFile = join(slidesDir, 'theme', 'layouts-base', 'videos.generated.json');
+
+function frontmatterOf(raw, file) {
+  // CRLF normaliseren: anders houdt de laatste waarde vóór de sluitende `---`
+  // een \r over, en parst YAML `start: 0` als de string "0\r".
+  const source = raw.replace(/\r\n/g, '\n');
+  if (!source.startsWith('---')) {
+    throw new Error(`${file}: geen frontmatter gevonden`);
+  }
+  const end = source.indexOf('\n---', 3);
+  if (end === -1) {
+    throw new Error(`${file}: frontmatter niet afgesloten`);
+  }
+  return parse(source.slice(3, end));
+}
+
+const videos = {};
+let themeCount = 0;
+
+for (const name of readdirSync(themesDir).filter(n => n.endsWith('.mdx')).sort()) {
+  const themeId = name.replace(/\.mdx$/, '');
+  const data = frontmatterOf(readFileSync(join(themesDir, name), 'utf8'), name);
+  if (!data?.videos) continue;
+  themeCount++;
+  for (const [key, video] of Object.entries(data.videos)) {
+    videos[`${themeId}/${key}`] = video;
+  }
+}
+
+writeFileSync(outFile, `${JSON.stringify(videos, null, 2)}\n`);
+console.log(
+  `sync-videos: ${Object.keys(videos).length} fragment(en) uit ${themeCount} hoofdstuk(ken) → ${
+    outFile.slice(projectRoot.length + 1)
+  }`,
+);

--- a/slides/theme/layouts-base/components/CourseVideo.vue
+++ b/slides/theme/layouts-base/components/CourseVideo.vue
@@ -1,0 +1,221 @@
+<!--
+  Klikbare titel die een fragment fullscreen afspeelt, met dezelfde start- en
+  eindtijd als in de cursustekst. De timing komt uit videos.generated.json, dat
+  `npm run sync:videos` uit de frontmatter van het hoofdstuk haalt.
+
+  Gebruik in een deck:  <CourseVideo id="inleiding/beethoven" label="Beethoven, 5e symfonie" />
+  Laat `label` weg en de titel uit de cursustekst wordt gebruikt.
+-->
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
+import videos from '../videos.generated.json';
+
+interface VideoEntry {
+  youtube: string;
+  title: string;
+  source: string;
+  start?: number;
+  end?: number;
+  aspectRatio?: string;
+}
+
+const props = defineProps<{ id: string; label?: string }>();
+
+const video = computed<VideoEntry | undefined>(
+  () => (videos as Record<string, VideoEntry>)[props.id],
+);
+const open = ref(false);
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+const embedUrl = computed(() => {
+  if (!video.value) return '';
+  const params = new URLSearchParams({ rel: '0', modestbranding: '1', autoplay: '1' });
+  if (video.value.start != null) params.set('start', String(video.value.start));
+  if (video.value.end != null) params.set('end', String(video.value.end));
+  return `https://www.youtube-nocookie.com/embed/${video.value.youtube}?${params}`;
+});
+
+const caption = computed(() => {
+  if (!video.value) return '';
+  const { title, start, end } = video.value;
+  if (start != null && end != null) return `${title} — Fragment ${formatTime(start)} — ${formatTime(end)}`;
+  if (start != null) return `${title} — Vanaf ${formatTime(start)}`;
+  return title;
+});
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    e.stopPropagation();
+    open.value = false;
+  }
+}
+
+// Slidev luistert zelf naar pijltjes en spatie; zolang de overlay openstaat mag
+// een toetsaanslag niet ook de presentatie doorbladeren.
+function swallowKeys(e: KeyboardEvent) {
+  if (e.key !== 'Escape') e.stopPropagation();
+}
+
+watch(open, isOpen => {
+  if (isOpen) {
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keyup', swallowKeys, true);
+  } else {
+    window.removeEventListener('keydown', onKeyDown, true);
+    window.removeEventListener('keyup', swallowKeys, true);
+  }
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown, true);
+  window.removeEventListener('keyup', swallowKeys, true);
+});
+</script>
+
+<template>
+  <button
+    v-if="video"
+    type="button"
+    class="course-video__trigger"
+    @click="open = true"
+  >
+    <span class="course-video__icon" aria-hidden="true">▶</span>
+    <span>{{ label ?? video.title }}</span>
+  </button>
+  <span v-else class="course-video__missing">
+    Onbekend fragment: {{ id }}
+  </span>
+
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="course-video__overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Video bekijken"
+      @click.self="open = false"
+    >
+      <div class="course-video__inner">
+        <iframe
+          class="course-video__player"
+          :src="embedUrl"
+          :title="video?.title"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        />
+        <div class="course-video__caption">
+          <span>{{ caption }}</span>
+          <span class="course-video__source">{{ video?.source }}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="course-video__close"
+        aria-label="Sluit video"
+        @click="open = false"
+      >
+        ✕
+      </button>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.course-video__trigger {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4em;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  border-bottom: 1px solid currentColor;
+  opacity: 0.9;
+}
+
+.course-video__trigger:hover,
+.course-video__trigger:focus-visible {
+  opacity: 1;
+  color: var(--slidev-theme-primary, currentColor);
+}
+
+.course-video__icon {
+  font-size: 0.7em;
+}
+
+.course-video__missing {
+  color: #b00;
+  font-family: monospace;
+  font-size: 0.8em;
+}
+
+.course-video__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.95);
+}
+
+.course-video__inner {
+  display: flex;
+  flex-direction: column;
+  width: min(90vw, 160vh);
+}
+
+.course-video__player {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: none;
+  background: #000;
+  display: block;
+}
+
+.course-video__caption {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding-top: 0.6rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.course-video__source {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.course-video__close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+  background: none;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.course-video__close:hover,
+.course-video__close:focus-visible {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.55);
+}
+</style>

--- a/slides/theme/layouts-base/videos.generated.json
+++ b/slides/theme/layouts-base/videos.generated.json
@@ -1,0 +1,364 @@
+{
+  "architectuur-en-bouwprincipes/sagrada": {
+    "youtube": "hWeNLNBHj4w",
+    "title": "Sagrada Família 4K Walking Tour",
+    "source": "Erman's Walkscapes"
+  },
+  "architectuur-en-bouwprincipes/fallingwater": {
+    "youtube": "q8dcnh-4I6g",
+    "title": "Inside Fallingwater",
+    "source": "OPEN SPACE"
+  },
+  "architectuur-en-bouwprincipes/sydney": {
+    "youtube": "51m-YvjmijI",
+    "title": "Sydney Opera House - Building an Icon",
+    "source": "The B1M"
+  },
+  "architectuur-en-bouwprincipes/gehry": {
+    "youtube": "VHVk0eAieXw",
+    "title": "The story of Frank Gehry",
+    "source": "BlessedArch"
+  },
+  "architectuur-en-bouwprincipes/meixihu": {
+    "youtube": "koAeUnhWNtw",
+    "title": "Meixihu / Changsha / Zaha Hadid Architects, 4K dronebeelden",
+    "source": "Felix Amiss"
+  },
+  "architectuur-en-bouwprincipes/mjostarnet": {
+    "youtube": "H-5SthXNT1A",
+    "title": "Mjøstårnet becomes the world's tallest timber building",
+    "source": "Moelven"
+  },
+  "art-nouveau-en-deco/horta-tour": {
+    "youtube": "tIo2VUz9A5c",
+    "title": "Major Town Houses of the Architect Victor Horta (UNESCO/NHK)",
+    "source": "UNESCO",
+    "start": 0
+  },
+  "art-nouveau-en-deco/chrysler-ad": {
+    "youtube": "Cif0FA1jHpo",
+    "title": "Architect Breaks Down the Design of the Chrysler Building",
+    "source": "Architectural Digest",
+    "start": 0
+  },
+  "art-nouveau-en-deco/difference-engine": {
+    "youtube": "_o3uejzyILY",
+    "title": "Babbage's Difference Engine No. 2 in werking",
+    "source": "Computer History Museum",
+    "start": 0
+  },
+  "art-nouveau-en-deco/bridging-the-rift": {
+    "youtube": "bby8gjUWFCE",
+    "title": "Arcane — Bridging the Rift, Part 3",
+    "source": "Riot Games",
+    "start": 0
+  },
+  "belgisch-experiment/rosas": {
+    "youtube": "mMTUdlEEM5A",
+    "title": "Rosas danst Rosas (film, 1997) — Thierry De Mey en Anne Teresa De Keersmaeker",
+    "source": "Rosas",
+    "start": 740,
+    "end": 876
+  },
+  "belgisch-experiment/logos": {
+    "youtube": "uU8Guq_AVK0",
+    "title": "Logos Robot Orchestra plays Music for an Appetite — Liesbeth Decrock",
+    "source": "Logos Foundation",
+    "start": 0,
+    "end": 180
+  },
+  "beweging-en-dynamiek/muybridge-film": {
+    "youtube": "FJA8ZbzPHHw",
+    "title": "The Horse In Motion - Sallie Gardner at a Gallop - 1878",
+    "source": "YouTube",
+    "start": 0
+  },
+  "beweging-en-dynamiek/riefenstahl": {
+    "youtube": "x6-0Cz73wwQ",
+    "title": "Olympia (proloog) - Leni Riefenstahl, 1938",
+    "source": "YouTube",
+    "start": 300
+  },
+  "beweging-en-dynamiek/pollock-film": {
+    "youtube": "6cgBvpjwOGo",
+    "title": "Jackson Pollock 51 - Hans Namuth, 1951",
+    "source": "YouTube",
+    "start": 350
+  },
+  "beweging-en-dynamiek/tinguely-film": {
+    "youtube": "5DZGu6xDKbM",
+    "title": "Jean Tinguely's Fire at MoMA",
+    "source": "Lost Art",
+    "start": 0
+  },
+  "beweging-en-dynamiek/strandbeest": {
+    "youtube": "MYGJ9jrbpvg",
+    "title": "Strandbeest Evolution",
+    "source": "Theo Jansen",
+    "start": 0
+  },
+  "beweging-en-dynamiek/teamlab-teaser": {
+    "youtube": "LOMbrwzqW4A",
+    "title": "teamLab Borderless Teaser Video",
+    "source": "teamLab",
+    "start": 0
+  },
+  "fotografie/sherman": {
+    "youtube": "0fPwsLeH8fA",
+    "title": "Sherman, Untitled Film Still",
+    "source": "Smarthistory"
+  },
+  "fotografie/muholi": {
+    "youtube": "s5WINxyy0I4",
+    "title": "\"I needed to remember me\" – Zanele Muholi on Somnyama Ngonyama",
+    "source": "Tate"
+  },
+  "graffiti-en-street-art/taki": {
+    "youtube": "fuJIoxX26t8",
+    "title": "Unseen Interview with Taki 183 & Blek le Rat in New York City",
+    "source": "YouTube",
+    "start": 0
+  },
+  "graffiti-en-street-art/chaka": {
+    "youtube": "gDruMDHSYTg",
+    "title": "Chaka — Infamous Graffiti Artist — Los Angeles",
+    "source": "YouTube",
+    "start": 0
+  },
+  "graffiti-en-street-art/pixadores": {
+    "youtube": "8m-dDNkq0jg",
+    "title": "PIXADORES (2014) — officiële trailer",
+    "source": "Amir Escandari",
+    "start": 0
+  },
+  "graffiti-en-street-art/bienal": {
+    "youtube": "4jzLf38PsBA",
+    "title": "Pixadores invadem a bienal 2008",
+    "source": "KMKZ",
+    "start": 0
+  },
+  "graffiti-en-street-art/style-wars": {
+    "youtube": "nUq5N0YRgcU",
+    "title": "Style Wars (1983)",
+    "source": "Tony Silver / Public Art Films",
+    "start": 0
+  },
+  "inleiding/beethoven": {
+    "youtube": "a9UApyClFKA",
+    "title": "Beethoven - Symphony No. 5 - Iván Fischer | Concertgebouworkest",
+    "source": "Concertgebouworkest",
+    "start": 7,
+    "end": 26
+  },
+  "inleiding/stravinsky": {
+    "youtube": "IGUZjBpeWT8",
+    "title": "Angelin Preljocaj Rite of spring 2004",
+    "source": "Dancing People",
+    "start": 2460,
+    "end": 2510
+  },
+  "inleiding/holiday": {
+    "youtube": "Web007rzSOI",
+    "title": "Billie Holiday-Strange fruit- HD",
+    "source": "prokoman1",
+    "start": 19,
+    "end": 61
+  },
+  "inleiding/troy": {
+    "youtube": "0c4v7fp5GC8",
+    "title": "Sinead O'Connor - Troy (Official Music Video)",
+    "source": "Sinéad O'Connor",
+    "start": 0
+  },
+  "instrumentontwikkeling/dowland": {
+    "youtube": "u3clX2CJqzs",
+    "title": "John Dowland — Flow My Tears",
+    "source": "Voices of Music",
+    "start": 0
+  },
+  "instrumentontwikkeling/hendrix": {
+    "youtube": "sjzZh6-h9fM",
+    "title": "Jimi Hendrix — The Star-Spangled Banner (Woodstock, 1969)",
+    "source": "Looky Lambert",
+    "start": 0
+  },
+  "instrumentontwikkeling/tharpe": {
+    "youtube": "5SoZG4yDaJA",
+    "title": "Sister Rosetta Tharpe — Didn't It Rain (Manchester, 1964)",
+    "source": "docludi2",
+    "start": 0
+  },
+  "instrumentontwikkeling/rockmore": {
+    "youtube": "XdFSU8sn3mo",
+    "title": "Clara Rockmore — The Swan (Saint-Saëns)",
+    "source": "Moog Music",
+    "start": 0
+  },
+  "instrumentontwikkeling/carlos": {
+    "youtube": "HI-mDTdeKR8",
+    "title": "Wendy Carlos, Soundtrack of Clockwork Orange",
+    "source": "Gamepadder",
+    "start": 0
+  },
+  "instrumentontwikkeling/derbyshire": {
+    "youtube": "qsRuhCflRyg",
+    "title": "How Delia Derbyshire made the Doctor Who theme (1965)",
+    "source": "BBC Archive",
+    "start": 0
+  },
+  "instrumentontwikkeling/nancarrow": {
+    "youtube": "pp2dWEYRzKY",
+    "title": "Conlon Nancarrow — Study for Player Piano No. 3a",
+    "source": "Jürgen Hocker",
+    "start": 0
+  },
+  "instrumentontwikkeling/avril": {
+    "youtube": "uxTdTaNIUxo",
+    "title": "Aphex Twin — Avril 14th",
+    "source": "Warp Records",
+    "start": 0
+  },
+  "instrumentontwikkeling/aisatsana": {
+    "youtube": "jVvLf0vJJ9s",
+    "title": "Aphex Twin — qisatsana",
+    "source": "NTS",
+    "start": 180
+  },
+  "instrumentontwikkeling/antheil": {
+    "youtube": "GZEtFwev630",
+    "title": "George Antheil — Ballet Mécanique, 16 robotpiano's",
+    "source": "Paul Lehrman / National Gallery of Art",
+    "start": 48
+  },
+  "instrumentontwikkeling/hat": {
+    "youtube": "YA1fDnjiyS8",
+    "title": "HAT (Hit Any Thing robot)",
+    "source": "Logos Foundation",
+    "start": 0
+  },
+  "licht-en-schaduw/sainte-chapelle-tour": {
+    "youtube": "hV3gjyKIMEo",
+    "title": "Sainte-Chapelle — virtuele rondleiding",
+    "source": "YouTube",
+    "start": 0
+  },
+  "licht-en-schaduw/flavin-doc": {
+    "youtube": "8kp3km-6EBw",
+    "title": "Dan Flavin — korte documentaire",
+    "source": "YouTube",
+    "start": 0
+  },
+  "licht-en-schaduw/lux-aeterna": {
+    "youtube": "j2cRjiC4ODI",
+    "title": "Ligeti — Lux Aeterna (Choeur de Radio France, live 2019)",
+    "source": "Radio France",
+    "start": 0,
+    "end": 180
+  },
+  "licht-en-schaduw/infinity-rooms": {
+    "youtube": "8VwJMw_fLvI",
+    "title": "Yayoi Kusama - Infinity Mirrors",
+    "source": "NPR",
+    "start": 0
+  },
+  "meerstemmigheid/chakrulo": {
+    "youtube": "6-2_zmiEFkQ",
+    "title": "Ensemble Rustavi — Chakrulo",
+    "source": "Rustavi",
+    "start": 0,
+    "end": 90
+  },
+  "meerstemmigheid/erraji": {
+    "youtube": "bhLv4XcauwQ",
+    "title": "Hassan Erraji — NIKRIZ (WOMAD 2011)",
+    "source": "WOMAD",
+    "start": 0,
+    "end": 60
+  },
+  "meerstemmigheid/leonin": {
+    "youtube": "_p9WQlyVPrA",
+    "title": "Léonin — Viderunt omnes (organum duplum)",
+    "source": "Early Music Consort of London, David Munrow",
+    "start": 0,
+    "end": 90
+  },
+  "meerstemmigheid/perotin": {
+    "youtube": "Q2JvIyStzNA",
+    "title": "Pérotin — Viderunt omnes (organum quadruplum)",
+    "source": "The Hilliard Ensemble",
+    "start": 0,
+    "end": 120
+  },
+  "meerstemmigheid/josquin-nymphes": {
+    "youtube": "2on2P7syDzQ",
+    "title": "Josquin — Nymphes des Bois (Déploration sur la mort d'Ockeghem)",
+    "source": "The Hilliard Ensemble, Paul Hillier",
+    "start": 0,
+    "end": 180
+  },
+  "meerstemmigheid/lotti-crucifixus": {
+    "youtube": "pLyB8nxvOeY",
+    "title": "Lotti — Crucifixus a 8",
+    "source": "Choir of King's College, Cambridge",
+    "start": 0
+  },
+  "meerstemmigheid/purcell-dido": {
+    "youtube": "nu1uoYELpPI",
+    "title": "Purcell — When I Am Laid In Earth (Dido's Lament)",
+    "source": "Catherine Bott, Academy of Ancient Music, Christopher Hogwood",
+    "start": 0
+  },
+  "meerstemmigheid/bach-gloria": {
+    "youtube": "cqxC8NvlVdY",
+    "title": "Bach — Gloria in excelsis (Mass in B Minor)",
+    "source": "Monteverdi Choir, English Baroque Soloists, John Eliot Gardiner",
+    "start": 0,
+    "end": 120
+  },
+  "onderwerpen-en-themas/teamlab": {
+    "youtube": "GTCXx8Em-KY",
+    "title": "New Tokyo TeamLab Azabudai Hills Full Walkthrough",
+    "source": "4K HDR Spatial Audio walkthrough",
+    "start": 120,
+    "end": 165
+  },
+  "onderwerpen-en-themas/banksy": {
+    "youtube": "Wr9Kr3Jsu-I",
+    "title": "Banksy mural removed from London's Royal Courts of Justice wall",
+    "source": "news pool, september 2025",
+    "start": 0
+  },
+  "perspectief-en-ruimte/deadpool": {
+    "youtube": "DLkDX7bdZ44",
+    "title": "Deadpool 4th wall breaks",
+    "source": "Tahed",
+    "start": 0,
+    "end": 40
+  },
+  "perspectief-en-ruimte/abramovic": {
+    "youtube": "xlf68X2qEpM",
+    "title": "Marina & Ulay @ MoMA (The Artist is Present)",
+    "source": "Isidora Smiljkovic",
+    "start": 0
+  },
+  "smaak-klasse-macht/bulgaars": {
+    "youtube": "WKzUnt_4_Do",
+    "title": "Le Mystère des Voix Bulgares — Pilentse Pee",
+    "source": "Le Mystère des Voix Bulgares Vol. 1"
+  },
+  "smaak-klasse-macht/gamelan": {
+    "youtube": "nGCSrC8RN6c",
+    "title": "Gamelan recorded in Peliatan, Bali, 1985",
+    "source": "Veldopname Bali, 1985"
+  },
+  "smaak-klasse-macht/banksy": {
+    "youtube": "iiO_1XRnMt4",
+    "title": "Banksy — Love is in the Bin (Director's Cut)",
+    "source": "Banksy"
+  },
+  "smaak-klasse-macht/warhol": {
+    "youtube": "Tk52hymgWQQ",
+    "title": "To the Bearer on Demand — Works by Andy Warhol",
+    "source": "Sotheby's"
+  }
+}


### PR DESCRIPTION
## Wat er verandert

De vier fragmenten van de inleiding stonden in het deck alleen als tekst ("→ Beethoven, 9e symfonie"), terwijl de site ze via `VideoOverlay.astro` gewoon afspeelt. Nu is de titel in het deck aanklikbaar en opent het fragment fullscreen, met dezelfde start- en eindtijd als in de cursustekst.

- **`slides/sync-videos.mjs`** leest de `videos:`-frontmatter van elk hoofdstuk en schrijft `videos.generated.json` — 60 fragmenten uit 13 hoofdstukken. Het bestand gaat mee in git, zodat `slidev dev` werkt zonder eerst te bouwen; `build:slides` synchroniseert eerst, zodat het niet kan verouderen.
- **`CourseVideo.vue`** in de gedeelde addon `layouts-base`, die elk deck al inlaadt. Gebruik: `<CourseVideo id="inleiding/beethoven" label="Beethoven, 5e symfonie" />`. Gedrag gespiegeld aan `VideoOverlay.astro`: lui geladen `youtube-nocookie`-iframe met `start`/`end`, bijschrift met de fragmenttijden, Escape sluit. Toetsaanslagen worden tegengehouden zolang de overlay openstaat, anders bladert Slidev de presentatie door achter de video.
- **`yaml`** stond alleen als transitieve dependency in de lockfile en is nu een expliciete devDependency.

### Afwijking van de goedgekeurde opzet

Afgesproken was `slides/<id>/videos.json` per deck. Het is één gedeeld bestand in de addon geworden, met sleutels `<theme-id>/<video-key>`. Reden: een component die globaal via de addon geregistreerd wordt, kan geen JSON uit de map van het deck importeren zonder per deck extra bedrading (een `setup/main.ts` per deck). Het principe blijft hetzelfde — gegenereerd, gecommit, één bron van waarheid — alleen staat het bestand een niveau hoger.

### Twee fouten die dit blootlegde

- Het deck zei "Beethoven, 9e symfonie" terwijl het fragment de Vijfde is; de presentatienotities op dezelfde slide zeggen dat ook. Gecorrigeerd.
- De eerste versie van het syncscript sneed de frontmatter zonder CRLF te normaliseren. Daardoor kwam de laatste waarde vóór de sluitende `---` als de string `"0\r"` in de JSON in plaats van het getal `0`, wat een kapotte `start`-parameter in de embed-URL geeft. Gevonden door de gebouwde bundle te inspecteren, niet door de build — die was groen. Opgelost.

## Issue

Closes #6

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — site en slides groen, 4 decks
- [x] `npm run sync:videos` — 60 fragmenten, geen waarde met een stray `\r`
- [x] Component daadwerkelijk geregistreerd: de scoped CSS (`course-video__trigger`) én de videomap met `start:7,end:26` zitten in de gebouwde deck-bundle — een niet-geregistreerde component zou daar niet in staan
- [x] Het gebouwde deck serveert: `/cursus-esthetica/slides/inleiding/` geeft HTTP 200 via `npm run preview`

Niet geverifieerd: het daadwerkelijk aanklikken en afspelen in een browser. De bewijzen hierboven dekken registratie, data en build, niet de klik zelf.

## Checkpoints

Ontwerpkeuze vooraf voorgelegd en beslist: gegenereerde JSON uit de hoofdstuk-frontmatter, boven props in het deck of een Vite-plugin die live meeleest.

Follow-up gemaakt: #13 — `meerstemmigheid` en `belgisch-experiment` embedden zeven video's al als inline iframes met hardgecodeerde tijden. Of die inline moeten blijven is een ontwerpkeuze, geen mechanische omzetting, dus niet hier meegenomen.