### PR TITLE
Troy bij dynamiek in plaats van bij klankkleur

### DIFF
--- a/slides/inleiding/slides.md
+++ b/slides/inleiding/slides.md
@@ -458,7 +458,7 @@ organisatie van tijd
 
 fluisteren ↔ schreeuwen
 
-→ bliksem in stille lucht
+<CourseVideo id="inleiding/troy" label="O'Connor, Troy" />
 
 ::q4::
 
@@ -468,14 +468,19 @@ de huid van het geluid
 
 <CourseVideo id="inleiding/holiday" label="Holiday, Strange Fruit" />
 
-<CourseVideo id="inleiding/troy" label="O'Connor, Troy" />
+→ en dezelfde Troy hiernaast
 
 <!--
 Hier laat je fragmenten horen — de eerste vier noten van Beethovens 5e (melodie als
 geheugen-haak), een passage uit Le Sacre (ritme dat in 1913 letterlijk een rel
-veroorzaakte in de Théâtre des Champs-Élysées), een Holiday-track ("Strange Fruit")
-en een O'Connor-track ("Troy") om hetzelfde te illustreren wat we bij beeld met de
-icoon en Rafaël deden: dezelfde noot, totaal andere stem.
+veroorzaakte in de Théâtre des Champs-Élysées), en "Troy" van O'Connor voor dynamiek:
+dat begint bijna gefluisterd en eindigt op volle stem, een bereik dat je in
+hedendaagse pop nauwelijks nog hoort omdat alles platgecomprimeerd wordt.
+
+Speel Troy bij klankkleur gewoon opnieuw, naast "Strange Fruit" van Holiday. Twee
+vrouwenstemmen die je geen seconde verwart — en meteen het punt van deze vier
+parameters: hetzelfde fragment draagt twee verschillende vragen. Ze zitten niet in
+het nummer, ze zitten in hoe je luistert.
 -->
 
 ---

--- a/src/content/themes/inleiding.mdx
+++ b/src/content/themes/inleiding.mdx
@@ -178,9 +178,9 @@ Om te beginnen heb je woorden nodig. Niet omdat kunst zich laat reduceren tot ee
 
 **Ritme** is de organisatie van tijd. Herhaling, accent, stilte. Strawinsky's [Le Sacre du Printemps](video:stravinsky) brak in 1913 door omdat het ritme onvoorspelbaar werd — en het publiek stond op om te vechten.
 
-**Dynamiek** is het verschil tussen fluisteren en schreeuwen in klank. Muziek zonder dynamiek is vlak. Beethoven gebruikt plotse luide akkoorden als bliksem in een stille lucht.
+**Dynamiek** is het verschil tussen fluisteren en schreeuwen in klank. Muziek zonder dynamiek is vlak. Beethoven gebruikt plotse luide akkoorden als bliksem in een stille lucht. In hedendaagse popmuziek hoor je dat bereik zelden nog: producties worden zo hard mogelijk gecomprimeerd, zodat alles even luid uit je speakers komt. Sinéad O'Connors [Troy](video:troy) doet het omgekeerde — het opent bijna gefluisterd en eindigt op volle stem.
 
-**Klankkleur** is waarom een viool anders klinkt dan een saxofoon, ook wanneer ze dezelfde noot spelen. Het is de huid van het geluid — wat een stem herkenbaar maakt als [Billie Holiday](video:holiday) of [Sinead O'Connor](video:troy).
+**Klankkleur** is waarom een viool anders klinkt dan een saxofoon, ook wanneer ze dezelfde noot spelen. Het is de huid van het geluid — wat een stem herkenbaar maakt als [Billie Holiday](video:holiday). Zet daar het fragment van O'Connor hierboven naast: twee vrouwenstemmen, en je verwart ze geen seconde. Datzelfde fragment gebruik je dus twee keer, voor twee verschillende dingen. Dat is het punt van deze parameters — het zijn geen eigenschappen van een nummer, het zijn manieren van luisteren die je erop loslaat.
 
 ### Drie vragen om mee te beginnen
 


### PR DESCRIPTION
## Wat er verandert

Klankkleur had twee fragmenten (Holiday én O'Connor), dynamiek had er geen — daar stond alleen "als bliksem in een stille lucht". *Troy* hoort bij dynamiek: het opent bijna gefluisterd en eindigt op volle stem, en dat bereik hoor je in hedendaagse popmuziek nauwelijks nog omdat producties platgecomprimeerd worden.

**`src/content/themes/inleiding.mdx`**

- **Dynamiek** krijgt `video:troy` plus het punt over compressie in moderne producties.
- **Klankkleur** houdt `video:holiday` en verwijst terug naar hetzelfde Troy-fragment in plaats van er een tweede keer naar te linken. Daar hangt de conclusie aan die de sectie eigenlijk nodig had: dat dezelfde opname twee verschillende vragen draagt, en dat die vier parameters dus manieren van luisteren zijn, geen eigenschappen van een nummer.

**`slides/inleiding/slides.md`**

- Het derde kwadrant krijgt `<CourseVideo id="inleiding/troy" />` in plaats van "→ bliksem in stille lucht"; het vierde houdt Holiday en verwijst ernaar terug.
- De presentatienotities onder de slide zijn meegeschreven, zodat het lesscript klopt met wat er staat — die noemden Troy nog als klankkleur-voorbeeld.

Ook de spelling *Sinead* → *Sinéad* in die alinea.

## Issue

Closes #15

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — site en slides groen
- [x] Elk van de vier `video:`-refs komt nog exact één keer voor in de body; alle keys bestaan in de frontmatter
- [x] Render-check via `npm run preview`: hoofdstuk HTTP 200 met vier videoknoppen en geen onverwerkte refs, deck HTTP 200

## Checkpoints

Geen — de wijziging was in de issue precies omschreven, inclusief de didactische reden. De enige toevoeging van mij is de slotzin bij klankkleur die het terugverwijzen expliciet maakt; die staat los en is makkelijk te schrappen als hij te veel uitlegt.