### PR TITLE
Haal de Arcane-regel uit de afspraken

### DIFF
--- a/.claude/skills/draft-theme-chapter/SKILL.md
+++ b/.claude/skills/draft-theme-chapter/SKILL.md
@@ -228,7 +228,7 @@ Movement-level checklist. Read your draft against it. Do not check by comparing 
 - **Reusing the same image across chapters without checking.** Inleiding and perspectief both use `monalisa.png`, `school-of-athens.png` — that's intentional cross-referencing. New chapters should reuse where it amplifies, never out of laziness.
 - **Auto-generating "drie vragen" or any other closer that exists in another chapter.** Each chapter's ending must come from its own argument.
 - **Forcing a cross-cultural pivot when the subject doesn't invite one.** A chapter on perspective in Western painting can carry a Tanizaki/Hiroshige beat well; a chapter on the Belgian art-school system probably can't. Use research to surface counterweights — don't manufacture them.
-- **Negeren van `docs/REDACTIE.md`.** Daar staan inhoudelijke afspraken (geen Arcane, SMOLE alleen als lesbeeld, Banksy ≠ graffiti, ...) die je niet uit de tekstbestanden kan afleiden. Lees het vóór het skelet.
+- **Negeren van `docs/REDACTIE.md`.** Daar staan inhoudelijke afspraken (SMOLE alleen als lesbeeld, Banksy ≠ graffiti, ...) die je niet uit de tekstbestanden kan afleiden. Lees het vóór het skelet.
 ## Canonical references
  
 When in doubt about voice, read `inleiding.mdx`. When in doubt about how a chapter handles multiple cultural registers within one argument, read the first half of `smaak-klasse-macht.mdx`. When in doubt about how a single concept (perspectief) carries an entire chapter through structural shifts, read `perspectief-en-ruimte.mdx`. When in doubt about how a finished chapter integrates Phase 1b research, end-of-chapter `## Bronnen`, and pure-markdown body, read `licht-en-schaduw.mdx`.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -113,9 +113,9 @@ Bij een gecombineerd issue (hoofdstuk *en* de component erin): neem de stops van
 het zwaarste type over. Overweeg om het te splitsen in twee issues als het werk
 in twee losse PR's beter te beoordelen is.
 
-Lees vóór elk inhoudelijk issue `docs/REDACTIE.md`. Daar staan afspraken (geen
-Arcane, Banksy hoort bij street art, citaatrecht als uitgangspunt, kritiek is
-geen default-essentie) die je niet uit de bestanden kan afleiden.
+Lees vóór elk inhoudelijk issue `docs/REDACTIE.md`. Daar staan afspraken (Banksy
+hoort bij street art, citaatrecht als uitgangspunt, landen krijgen "haar",
+kritiek is geen default-essentie) die je niet uit de bestanden kan afleiden.
 
 ## Stap 3 — Per issue
 

--- a/docs/REDACTIE.md
+++ b/docs/REDACTIE.md
@@ -7,17 +7,6 @@ skill verwijst hiernaar).
 
 ## Voorbeelden en verwijzingen
 
-- **Arcane niet binnenhalen in nieuw materiaal.** Bewuste didactische
-  conclusie na een jaar proberen (aansluiting leefwereld leerlingen
-  werkte niet). Bij het omzetten van oud materiaal Arcane-beats
-  schrappen zonder ze opnieuw voor te stellen; Arcane-materiaal in oude
-  powerpoints niet overnemen.
-  **Uitzondering: `art-nouveau-en-deco`.** Dat hoofdstuk is bewust rond
-  Arcane opgebouwd — de serie is er niet de leefwereld-aanhaking maar
-  het bewijsstuk: Piltover in art deco, Zaun in art nouveau, precies de
-  klassentegenstelling die het hoofdstuk uitlegt. Die opzet blijft. De
-  regel hierboven gaat over Arcane erbij halen, niet over dit hoofdstuk.
-  (Vastgesteld aug 2026, bij de leespas van #17.)
 - **SMOLE** (graffiti-schrijver, actief in Frankrijk/België, cartooneske
   kippen, treinen): onverifieerbaar via bronnen, dus niet in cursustekst.
   Wel bruikbaar als beeldmateriaal in powerpoints tijdens de les.


### PR DESCRIPTION
## Wat er verandert

`docs/REDACTIE.md` verbood Arcane in cursusteksten. Die afspraak gaat eruit.

De regel kwam voort uit een plan om meerdere lessen rond Arcane te bouwen. Dat werkte niet — dat is een goede conclusie, maar ze is blijven staan als een verbod op de serie zelf, en dat is te breed. Het ene hoofdstuk dat er wél op draait zit inhoudelijk goed. En de kans dat een nieuw hoofdstuk toevallig bij Arcane uitkomt is klein; gebeurt het toch, dan hoort dat op eigen merites beoordeeld te worden in plaats van tegen een staande regel aan te lopen.

De uitzondering die ik bij #17 toevoegde gaat mee weg. Zonder regel valt er niets uit te zonderen.

**Op drie plaatsen**, want alleen `REDACTIE.md` opschonen laat de regel voortleven in de skills die hem als voorbeeld citeren:

- `docs/REDACTIE.md` — de volledige bullet, inclusief de uitzondering
- `.claude/skills/draft-theme-chapter/SKILL.md` — "geen Arcane" uit de opsomming in de valkuilen
- `.claude/skills/work-issues/SKILL.md` — idem bij stap 2; daar staat nu "landen krijgen *haar*" in de plaats, een afspraak die wel actueel is

SMOLE en Banksy blijven staan en nemen de voorbeeldrol over.

De achttien vermeldingen van Arcane in `art-nouveau-en-deco.mdx` blijven ongemoeid — dat is de cursustekst, niet de afspraak.

## Issue

Closes #25

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — site en slides groen
- [x] Grep over `docs/`, `.claude/skills/` en `CLAUDE.md`: geen enkele verwijzing naar Arcane meer; de 18 in het hoofdstuk zelf staan er nog
- [x] Render-check niet van toepassing: alleen afspraken en skills, geen paginainhoud

## Checkpoints

Geen — de beslissing en de motivering kwamen van de auteur.