### PR TITLE
Normaliseer regeleindes repo-breed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Wat er verandert

Eén regel: `.gitattributes` met `* text=auto eol=lf`.

`npm run build` draait `sync:videos`, en dat script schreef `videos.generated.json` met LF terwijl git het met CRLF uitcheckte. Gevolg: na elke build stond dat bestand als gewijzigd in `git status` terwijl `git diff` leeg was. Vervelender dan het klinkt — stap 0 van `/work-issues` eist een schone working tree, dus elke build zette een valse blokkade neer.

### Wat het werkelijk was

De blobs in de index stonden al op LF. `git add --renormalize .` stageerde dan ook nul bestanden. De oorzaak lag in de stat-cache van de index: git vergelijkt bij gelijke bestandsgrootte de inhoud niet, waardoor de CRLF-versies op schijf bleven staan. Een geforceerde her-checkout zette de 158 tekstbestanden alsnog op LF.

De commit bevat daardoor precies één bestand. De rest was werk aan de working copy, niet aan de geschiedenis.

## Issue

Closes #19

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — site en 4 slidedecks, exit 0
- [x] **De kern**: `npm run sync:videos` gevolgd door `git status --porcelain` geeft nu lege output. Vóór deze fix stond `videos.generated.json` daar altijd
- [x] Alle 368 getrackte jpg/png/woff2/ico byte-identiek aan hun index-blob na de hernormalisatie — geen enkel binair bestand geraakt
- [x] Render-check: `/cursus-esthetica/inleiding/` geeft HTTP 200 met de juiste titel
- [x] Bestandstelling: 526 → 527 (alleen `.gitattributes` erbij)

## Checkpoints

De keuze tussen smal (één bestand) en repo-breed is vooraf voorgelegd; repo-breed gekozen, zodat ook de "LF will be replaced by CRLF"-waarschuwing bij elke commit verdwijnt.