### PR TITLE
Schrap het dode frontmatter-veld id:

### DIFF
--- a/.claude/skills/add-interactive-component/SKILL.md
+++ b/.claude/skills/add-interactive-component/SKILL.md
@@ -171,7 +171,6 @@ Each chapter's `.mdx` file imports and uses the component directly. Goal: the MD
 
 ```mdx
 ---
-id: wat-is-kunst
 title: Wat is kunst?
 module: waarnemen
 order: 0

--- a/.claude/skills/draft-theme-chapter/SKILL.md
+++ b/.claude/skills/draft-theme-chapter/SKILL.md
@@ -16,7 +16,7 @@ Do NOT use `smaak-klasse-macht.mdx` as a length reference — it overshoots. Use
  
 ### Werkplek
  
-De skill draait in de repo-root. Schrijf alle prose — initiële MDX, snoei, latere revisies — rechtstreeks naar `src/content/themes/<slug>.mdx`. Beelden landen onder `public/images/<theme-id>/`.
+De skill draait in de repo-root. Schrijf alle prose — initiële MDX, snoei, latere revisies — rechtstreeks naar `src/content/themes/<theme-id>.mdx`. Beelden landen onder `public/images/<theme-id>/`. `<theme-id>` is één en dezelfde waarde overal: de bestandsnaam zonder extensie. Die bepaalt ook de URL — er is geen apart `id:`-veld in de frontmatter (zie Phase 3).
  
 ## What the voice is doing (and what to imitate)
  
@@ -108,7 +108,9 @@ Input: the signed-off skeleton (Phase 1) and signed-off asset list (Phase 2).
  
 #### Frontmatter
  
-Match the existing schema exactly. Mandatory fields: `id`, `title`, `module`, `order`, `figure`, `shortDescription`. Optional: `accentColor`, `image` (header image).
+Match the existing schema exactly (`src/content.config.ts`). Mandatory fields: `title`, `module`, `order`, `figure`, `shortDescription`. Optional: `accentColor`, `image` (header image).
+
+**There is no `id` field.** The filename without extension *is* the chapter id: it produces the URL (`[theme].astro` routes on the glob-loader id), and it is the `<theme-id>` in `public/images/<theme-id>/` and `slides/<theme-id>/`. Choose the filename deliberately — renaming later means moving those directories too. Never add `id:` to the frontmatter: the schema does not declare it, zod strips it silently, and a value that drifts from the filename makes the URL look like something it is not.
  
 **Do not set `customStyles`, `customLayout`, or `customHeader`.** These are visual customisations the user adds later if needed. The skill produces the chapter content; styling is a separate decision the user owns.
  

--- a/docs/BRIEFING.md
+++ b/docs/BRIEFING.md
@@ -162,7 +162,6 @@ import { defineCollection, z } from 'astro:content';
 const modules = defineCollection({
   type: 'content',
   schema: z.object({
-    id: z.string(),          // 'kunst-wetenschap'
     title: z.string(),        // 'Kunst en wetenschap'
     order: z.number(),        // Voor volgorde op homepage
     intro: z.string(),        // Korte beschrijving
@@ -172,9 +171,8 @@ const modules = defineCollection({
 const themes = defineCollection({
   type: 'content',
   schema: z.object({
-    id: z.string(),           // 'perspectief-en-ruimte'
     title: z.string(),
-    module: z.string(),       // FK naar module.id
+    module: z.string(),       // FK naar de module-id (= bestandsnaam)
     order: z.number(),        // Volgorde binnen module
     shortDescription: z.string(),
     figure: z.string(),       // '01', '02', etc.
@@ -190,13 +188,29 @@ const themes = defineCollection({
 export const collections = { modules, themes };
 ```
 
+### De bestandsnaam is de identiteit
+
+Geen van beide collecties heeft een `id`-veld in de frontmatter. De glob-loader
+leidt de entry-id af van de bestandsnaam zonder extensie, en dat is meteen de
+sleutel voor alles wat aan een hoofdstuk hangt:
+
+- de URL — `[theme].astro` routeert op `theme.id`;
+- de map met beelden, `public/images/<theme-id>/`;
+- het slidedeck, `slides/<theme-id>/slides.md` (zie `src/lib/has-slides.ts`);
+- de `module:` in een thema, die naar de bestandsnaam van een module verwijst.
+
+Een hoofdstuk hernoemen is dus het bestand hernoemen (en de bijbehorende
+beeld- en slidesmap mee). Zet **geen** `id:` in de frontmatter: het schema kent
+het veld niet, zod stript het stil, en een waarde die van de bestandsnaam
+afwijkt wekt de indruk dat de URL iets anders is dan hij is.
+
 ### Voorbeeld thema-bestand
 
-`src/content/themes/perspectief-en-ruimte.mdx`:
+`src/content/themes/perspectief-en-ruimte.mdx` — deze bestandsnaam levert de
+route `/perspectief-en-ruimte/`:
 
 ```mdx
 ---
-id: perspectief-en-ruimte
 title: Perspectief en ruimte
 module: kunst-wetenschap
 order: 1
@@ -249,7 +263,7 @@ import ThemeLayout from '../layouts/ThemeLayout.astro';
 export async function getStaticPaths() {
   const themes = await getCollection('themes');
   return themes.map(theme => ({
-    params: { theme: theme.data.id },
+    params: { theme: theme.id },   // loader-id = bestandsnaam
     props: { theme }
   }));
 }

--- a/src/content/modules/betekenis-en-taal.md
+++ b/src/content/modules/betekenis-en-taal.md
@@ -1,5 +1,4 @@
 ---
-id: betekenis-en-taal
 title: Betekenis en taal
 order: 2
 intro: Kunst als drager van inhoud. Wat kunstenaars verbeelden, welke symbolen ze inzetten, en hoe we kunst leren lezen als een taal met eigen syntaxis.

--- a/src/content/modules/kijken-en-luisteren.md
+++ b/src/content/modules/kijken-en-luisteren.md
@@ -1,5 +1,4 @@
 ---
-id: kijken-en-luisteren
 title: Kijken en luisteren
 order: 1
 intro: De zintuiglijke bouwstenen. Hoe registreert het oog ruimte, licht en kleur — en hoe vormt het oor klank tot betekenis? Zeven lessen over de grammatica van waarneming.

--- a/src/content/modules/kunst-en-samenleving.md
+++ b/src/content/modules/kunst-en-samenleving.md
@@ -1,5 +1,4 @@
 ---
-id: kunst-en-samenleving
 title: Kunst en samenleving
 order: 5
 intro: Kunst als protest, als identiteit, als commentaar op de media en het digitale. De breedste module — waar esthetiek botst met het nu.

--- a/src/content/modules/kunst-en-wetenschap.md
+++ b/src/content/modules/kunst-en-wetenschap.md
@@ -1,5 +1,4 @@
 ---
-id: kunst-en-wetenschap
 title: Kunst en wetenschap
 order: 3
 intro: Van Leonardo's anatomische schetsen tot algoritmische beelden. Deze module volgt de kruisbestuiving tussen artistieke verbeelding en wetenschappelijk onderzoek — en waarom ze nooit echt gescheiden werelden waren.

--- a/src/content/modules/ornament-en-stijl.md
+++ b/src/content/modules/ornament-en-stijl.md
@@ -1,5 +1,4 @@
 ---
-id: ornament-en-stijl
 title: Ornament en stijl
 order: 4
 intro: Hoe een periode zichzelf uitdrukt in lijn, decoratie en materiaal. Art nouveau naast art deco, animatie als totaalesthetiek — stijl als zichtbare tijdgeest.

--- a/src/content/themes/animatie-als-kunst.mdx
+++ b/src/content/themes/animatie-als-kunst.mdx
@@ -1,5 +1,4 @@
 ---
-id: animatie-als-kunst
 title: Animatie als kunst
 module: ornament-en-stijl
 order: 2

--- a/src/content/themes/architectuur-en-bouwprincipes.mdx
+++ b/src/content/themes/architectuur-en-bouwprincipes.mdx
@@ -1,5 +1,4 @@
 ---
-id: architectuur-en-bouwprincipes
 title: Hoe bouw je wat je niet kunt tekenen?
 module: kunst-en-wetenschap
 order: 1

--- a/src/content/themes/architectuur-en-design.mdx
+++ b/src/content/themes/architectuur-en-design.mdx
@@ -1,5 +1,4 @@
 ---
-id: architectuur-en-design
 title: Architectuur en design
 module: kunst-en-wetenschap
 order: 5

--- a/src/content/themes/art-nouveau-en-deco.mdx
+++ b/src/content/themes/art-nouveau-en-deco.mdx
@@ -1,5 +1,4 @@
 ---
-id: art-nouveau-en-deco
 title: Voor wie is de toekomst gebouwd?
 module: ornament-en-stijl
 order: 1

--- a/src/content/themes/belgisch-experiment.mdx
+++ b/src/content/themes/belgisch-experiment.mdx
@@ -1,5 +1,4 @@
 ---
-id: belgisch-experiment
 title: Voor wie maakt België kunst?
 module: kunst-en-samenleving
 order: 7

--- a/src/content/themes/beweging-en-dynamiek.mdx
+++ b/src/content/themes/beweging-en-dynamiek.mdx
@@ -1,5 +1,4 @@
 ---
-id: beweging-en-dynamiek
 title: Waar zit de beweging?
 module: kijken-en-luisteren
 order: 6

--- a/src/content/themes/digitale-kunst.mdx
+++ b/src/content/themes/digitale-kunst.mdx
@@ -1,5 +1,4 @@
 ---
-id: digitale-kunst
 title: Digitale kunst
 module: kunst-en-samenleving
 order: 6

--- a/src/content/themes/fotografie.mdx
+++ b/src/content/themes/fotografie.mdx
@@ -1,5 +1,4 @@
 ---
-id: fotografie
 title: Kan een machine kunst maken?
 module: kunst-en-wetenschap
 order: 3

--- a/src/content/themes/graffiti-en-street-art.mdx
+++ b/src/content/themes/graffiti-en-street-art.mdx
@@ -1,5 +1,4 @@
 ---
-id: graffiti-en-street-art
 title: Voor wie schrijf je je naam?
 module: kunst-en-samenleving
 order: 1

--- a/src/content/themes/hedendaagse-expressie.mdx
+++ b/src/content/themes/hedendaagse-expressie.mdx
@@ -1,5 +1,4 @@
 ---
-id: hedendaagse-expressie
 title: Hedendaagse expressie
 module: kunst-en-samenleving
 order: 3

--- a/src/content/themes/inleiding.mdx
+++ b/src/content/themes/inleiding.mdx
@@ -1,5 +1,4 @@
 ---
-id: inleiding
 title: Maar is het kunst?
 module: kijken-en-luisteren
 order: 1

--- a/src/content/themes/instrumentontwikkeling.mdx
+++ b/src/content/themes/instrumentontwikkeling.mdx
@@ -1,5 +1,4 @@
 ---
-id: instrumentontwikkeling
 title: Wie speelt er eigenlijk?
 module: kijken-en-luisteren
 order: 5

--- a/src/content/themes/kleur-en-emotie.mdx
+++ b/src/content/themes/kleur-en-emotie.mdx
@@ -1,5 +1,4 @@
 ---
-id: kleur-en-emotie
 title: Kleur en emotie
 module: kijken-en-luisteren
 order: 7

--- a/src/content/themes/kunst-en-wiskunde.mdx
+++ b/src/content/themes/kunst-en-wiskunde.mdx
@@ -1,5 +1,4 @@
 ---
-id: kunst-en-wiskunde
 title: Kunst en wiskunde
 module: kunst-en-wetenschap
 order: 4

--- a/src/content/themes/leonardo-da-vinci.mdx
+++ b/src/content/themes/leonardo-da-vinci.mdx
@@ -1,5 +1,4 @@
 ---
-id: leonardo-da-vinci
 title: Leonardo da Vinci
 module: kunst-en-wetenschap
 order: 2

--- a/src/content/themes/licht-en-schaduw.mdx
+++ b/src/content/themes/licht-en-schaduw.mdx
@@ -1,5 +1,4 @@
 ---
-id: licht-en-schaduw
 title: Wanneer wordt licht zelf het werk?
 module: kijken-en-luisteren
 order: 3

--- a/src/content/themes/meerstemmigheid.mdx
+++ b/src/content/themes/meerstemmigheid.mdx
@@ -1,5 +1,4 @@
 ---
-id: meerstemmigheid
 title: Wat hoor je tegelijk?
 module: kijken-en-luisteren
 order: 4

--- a/src/content/themes/onderwerpen-en-themas.mdx
+++ b/src/content/themes/onderwerpen-en-themas.mdx
@@ -1,5 +1,4 @@
 ---
-id: onderwerpen-en-themas
 title: Wat verdient een schilderij?
 module: betekenis-en-taal
 order: 1

--- a/src/content/themes/perspectief-en-ruimte.mdx
+++ b/src/content/themes/perspectief-en-ruimte.mdx
@@ -1,5 +1,4 @@
 ---
-id: perspectief-en-ruimte
 title: Wie mag in het midden staan?
 module: kijken-en-luisteren
 order: 2

--- a/src/content/themes/protest-en-identiteit.mdx
+++ b/src/content/themes/protest-en-identiteit.mdx
@@ -1,5 +1,4 @@
 ---
-id: protest-en-identiteit
 title: Protest en identiteit
 module: kunst-en-samenleving
 order: 4

--- a/src/content/themes/smaak-klasse-macht.mdx
+++ b/src/content/themes/smaak-klasse-macht.mdx
@@ -1,5 +1,4 @@
 ---
-id: smaak-klasse-macht
 title: Wie heeft jouw smaak gemaakt?
 module: kunst-en-samenleving
 order: 2

--- a/src/content/themes/symboliek.mdx
+++ b/src/content/themes/symboliek.mdx
@@ -1,5 +1,4 @@
 ---
-id: symboliek
 title: Symboliek
 module: betekenis-en-taal
 order: 2

--- a/src/content/themes/wereldculturen.mdx
+++ b/src/content/themes/wereldculturen.mdx
@@ -1,5 +1,4 @@
 ---
-id: wereldculturen
 title: Wereldculturen
 module: kunst-en-samenleving
 order: 3


### PR DESCRIPTION
## Wat er verandert

Elk hoofdstuk begon met een `id:`-veld dat niets deed: het staat niet in het themes-schema van `src/content.config.ts`, dus zod stripte het, en `src/pages/[theme].astro` routeert op `theme.id` — de id van de glob-loader, afgeleid van de bestandsnaam.

Dat blijft onzichtbaar zolang beide waarden toevallig gelijk zijn, en precies daar ging het mis bij `fotografie-en-film.mdx` (#5): de frontmatter zei `fotografie`, de URL werd `fotografie-en-film`. De `draft-theme-chapter` skill schreef het veld bovendien voor als verplicht, dus elk nieuw hoofdstuk liep hetzelfde risico.

**31 bestanden**, elk precies één regel korter: 23 thema's en — niet voorzien in het issue — 5 modules, die hetzelfde dode veld hadden. Consequent meegenomen.

**Drie documenten gelijkgetrokken**, want daar zat de eigenlijke val:

- `draft-theme-chapter/SKILL.md` — noemde `id` verplicht; vervangen door een expliciete regel dat de bestandsnaam de identiteit is
- `add-interactive-component/SKILL.md` — `id:` uit het MDX-voorbeeld
- `docs/BRIEFING.md` — uit beide zod-schema's en het voorbeeldbestand, `theme.data.id` → `theme.id`, plus een sectie over de bestandsnaam als sleutel

Geen enkel codepad las `data.id`. Alle `theme.id` en `module.id` in `src/` zijn loader-ids en bleven ongemoeid.

## Issue

Closes #7

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — site en 4 slidedecks, exit 0
- [x] **Geen enkele URL gewijzigd** — de gebouwde routes onder `dist/` vóór en na vergeleken: 28 tegen 28, lijsten identiek. Dat was het risico van dit issue
- [x] Render-check: `/`, `/fotografie/`, `/inleiding/`, `/graffiti-en-street-art/`, `/meerstemmigheid/` en `/slides/meerstemmigheid/` alle HTTP 200 met de juiste titel; `/fotografie-en-film/` blijft 404
- [x] Geen `^id:` meer in `src/content/`

## Checkpoints

De richting — veld schrappen tegenover veld echt maken en erop routeren — is vooraf voorgelegd. Schrappen gekozen: minder bewegende delen, en de bestandsnaam is al de facto de sleutel voor slides en beelden.

Follow-up #28 aangemaakt: documentatie die nog naar een niet meer bestaand `wat-is-kunst` wijst, en de openstaande afweging of `content.config.ts` `.strict()` moet krijgen — zonder dat wordt een herintroductie van `id:` nog altijd stil gestript.