### PR TITLE
Voed de inline videospelers uit videos.generated.json

### DIFF
--- a/slides/belgisch-experiment/slides.md
+++ b/slides/belgisch-experiment/slides.md
@@ -60,12 +60,7 @@ gaan we vragen *hoe*.
 
 <div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
 
-<iframe
-  src="https://www.youtube.com/embed/mMTUdlEEM5A?start=740&end=876"
-  style="width: 60%; aspect-ratio: 16/9; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="belgisch-experiment/rosas" style="width: 60%;" />
 
 <div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
 
@@ -710,12 +705,7 @@ backgroundSize: contain
 
 <div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
 
-<iframe
-  src="https://www.youtube.com/embed/uU8Guq_AVK0?start=0&end=180"
-  style="width: 60%; aspect-ratio: 16/9; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="belgisch-experiment/logos" style="width: 60%;" />
 
 <div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
 

--- a/slides/meerstemmigheid/slides.md
+++ b/slides/meerstemmigheid/slides.md
@@ -139,12 +139,7 @@ ze heeft geheugen. Andere tradities behouden polyfonie mondeling — eindeloos v
 
 <div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
 
-<iframe
-  src="https://www.youtube.com/embed/_p9WQlyVPrA?start=0&end=90"
-  style="width: 60%; aspect-ratio: 16/9; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="meerstemmigheid/leonin" style="width: 60%;" />
 
 <div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
 
@@ -367,12 +362,7 @@ slimme zet: de componist staat centraal.
 
 <div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
 
-<iframe
-  src="https://www.youtube.com/embed/2on2P7syDzQ?start=0&end=180"
-  style="width: 60%; aspect-ratio: 16/9; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="meerstemmigheid/josquin-nymphes" style="width: 60%;" />
 
 <div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
 
@@ -440,12 +430,7 @@ nobis — zit hier het hele verhaal in.
 
 ## 
 
-<iframe
-  src="https://www.youtube.com/embed/pLyB8nxvOeY"
-  style="width: 100%; height: 80%; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="meerstemmigheid/lotti-crucifixus" style="height: 80%;" />
 
 <!--
 Choir of King's College, Cambridge. Laat de eerste twee minuten horen. Vraag de klas
@@ -560,12 +545,7 @@ verticaal.
 
 ## 
 
-<iframe
-  src="https://www.youtube.com/embed/nu1uoYELpPI"
-  style="width: 100%; height: 80%; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="meerstemmigheid/purcell-dido" style="height: 80%;" />
 
 <!--
 Catherine Bott, Academy of Ancient Music, Christopher Hogwood. Tijdens het luisteren:
@@ -614,12 +594,7 @@ harmonie zijn niet meer twee benaderingen. Ze zijn één.
 
 ## 
 
-<iframe
-  src="https://www.youtube.com/embed/cqxC8NvlVdY?start=0&end=120"
-  style="width: 100%; height: 80%; border: 1.5px solid var(--color-rule);"
-  allow="autoplay; encrypted-media"
-  allowfullscreen
-></iframe>
+<CourseVideoInline id="meerstemmigheid/bach-gloria" style="height: 80%;" />
 
 <!--
 Monteverdi Choir, English Baroque Soloists, John Eliot Gardiner. Eerste twee minuten.

--- a/slides/theme/layouts-base/components/CourseVideoInline.vue
+++ b/slides/theme/layouts-base/components/CourseVideoInline.vue
@@ -1,0 +1,88 @@
+<!--
+  Speler die het fragment op de slide zelf afspeelt, in plaats van fullscreen
+  zoals CourseVideo. Bedoeld voor slides waar het beeld naast iets anders moet
+  staan — een partituur, een tekstkolom — en waar wegklikken naar een overlay
+  het punt kapotmaakt.
+
+  Zelfde databron als CourseVideo: de timing komt uit videos.generated.json,
+  dat `npm run sync:videos` uit de frontmatter van het hoofdstuk haalt. Zo staan
+  YouTube-id en tijden op één plaats, in de cursustekst.
+
+  Gebruik in een deck:  <CourseVideoInline id="meerstemmigheid/leonin" style="width: 60%;" />
+
+  Afmeting komt van de aanroeper: geef `style` of `class` mee, die vallen door
+  naar de wrapper. Zonder afmeting is het 100% breed op 16/9. Wil je een vaste
+  hoogte (`height: 80%`), zet die dan op de wrapper — de iframe vult hem.
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import videos from '../videos.generated.json';
+
+interface VideoEntry {
+  youtube: string;
+  title: string;
+  source: string;
+  start?: number;
+  end?: number;
+  aspectRatio?: string;
+}
+
+const props = defineProps<{ id: string }>();
+
+const video = computed<VideoEntry | undefined>(
+  () => (videos as Record<string, VideoEntry>)[props.id],
+);
+
+// Geen autoplay: een slide die uit zichzelf begint te spelen zodra je erop
+// belandt, neemt de les over. De docent drukt zelf op play.
+const embedUrl = computed(() => {
+  if (!video.value) return '';
+  const params = new URLSearchParams({ rel: '0', modestbranding: '1' });
+  if (video.value.start != null) params.set('start', String(video.value.start));
+  if (video.value.end != null) params.set('end', String(video.value.end));
+  return `https://www.youtube-nocookie.com/embed/${video.value.youtube}?${params}`;
+});
+</script>
+
+<template>
+  <div v-if="video" class="course-video-inline">
+    <iframe
+      class="course-video-inline__player"
+      :src="embedUrl"
+      :title="video.title"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    />
+  </div>
+  <span v-else class="course-video-inline__missing">
+    Onbekend fragment: {{ id }}
+  </span>
+</template>
+
+<style scoped>
+.course-video-inline {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border: 1.5px solid var(--color-rule);
+}
+
+/* Absoluut gepositioneerd, zodat de iframe de wrapper vult of die nu zijn
+   hoogte uit de aspect-ratio haalt of uit een meegegeven `height`. */
+.course-video-inline__player {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
+.course-video-inline__missing {
+  color: #b00;
+  font-family: monospace;
+  font-size: 0.8em;
+}
+</style>


### PR DESCRIPTION
## Wat er verandert

`meerstemmigheid` en `belgisch-experiment` embedden zeven video's als losse iframes met hardgecodeerde YouTube-id's en tijden — precies de duplicatie die #6 elders wegnam. Dezelfde fragmenten staan namelijk ook in de `videos:`-frontmatter van de bijbehorende hoofdstukken, en die twee konden uit elkaar lopen.

Nieuw: **`CourseVideoInline.vue`** naast de bestaande `CourseVideo.vue`, in dezelfde addon zodat elk deck hem krijgt. Zelfde databron en zelfde `id`-prop met sleutel `<theme-id>/<video-key>`, maar de speler blijft op de slide staan in plaats van fullscreen te openen.

Alle zeven omgezet: `leonin`, `josquin-nymphes`, `lotti-crucifixus`, `purcell-dido` en `bach-gloria` in meerstemmigheid, `rosas` en `logos` in belgisch-experiment. Elk fragment kwam op YouTube-id én start/end exact overeen met de frontmatter, dus geen enkele hoefde te blijven staan en de cursustekst is niet aangeraakt.

## Issue

Closes #13

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings (56 bestanden)
- [x] `npm run build` — site en 4 slidedecks, exit 0
- [x] **Component echt geregistreerd**, niet stil genegeerd: de gebouwde bundel importeert `CourseVideoInline` rechtstreeks in plaats van via `resolveComponent()`, en de scoped klasse zit in de CSS. Een niet-geregistreerde Vue-component geeft geen buildfout, alleen een runtime-waarschuwing — vandaar deze check
- [x] Alle zeven YouTube-id's zitten in de bundel; geen enkele `https://www.youtube.com/embed/` meer over in de decks
- [x] Tijden komen als getallen mee (`start:0,end:90`), niet als strings — dezelfde val als de CRLF-bug uit #6
- [x] Render-check: beide decks HTTP 200 via `npm run preview`

## Checkpoints

De keuze is vooraf voorgelegd: inline houden en uit de JSON voeden, in plaats van alles omzetten naar de fullscreen `CourseVideo`. Reden om inline te houden: bij een muziekhoofdstuk wil je de speler naast de partituur op de slide kunnen zien.