### PR TITLE
Dode docsverwijzingen weg en strict op de contentschema's

### DIFF
--- a/.claude/skills/add-interactive-component/SKILL.md
+++ b/.claude/skills/add-interactive-component/SKILL.md
@@ -35,7 +35,7 @@ The user describes what the component should do without providing a prototype. I
 
 ## Placement decision
 
-**Chapter-specific (`src/components/themes/<chapter-id>/`):** the component's *content* is tied to one chapter. The definition-test in "wat-is-kunst" contains six specific scenarios and four specific philosophers — moving it to another chapter would require rewriting it. Most interactive components will be chapter-specific.
+**Chapter-specific (`src/components/themes/<chapter-id>/`):** the component's *content* is tied to one chapter. The definition-test in "inleiding" contains six specific scenarios and four specific philosophers — moving it to another chapter would require rewriting it. Most interactive components will be chapter-specific.
 
 **Reusable (`src/components/interactive/`):** the component is a *pattern* that takes content as props. A three-minute timed viewer works for any artwork. A before/after comparator works for any pair of images. Only build as reusable when there is a concrete second use case in mind — speculative abstraction is costly here.
 
@@ -171,14 +171,14 @@ Each chapter's `.mdx` file imports and uses the component directly. Goal: the MD
 
 ```mdx
 ---
-title: Wat is kunst?
-module: waarnemen
-order: 0
-figure: "00"
+title: Maar is het kunst?
+module: kijken-en-luisteren
+order: 1
+figure: "01"
 shortDescription: ...
 ---
 
-import DefinitionTest from '../../components/themes/wat-is-kunst/DefinitionTest.astro';
+import DefinitionTest from '../../components/themes/inleiding/DefinitionTest.astro';
 
 ## Geen definitie, wel een spel
 
@@ -241,10 +241,10 @@ When completing an integration, report back with:
 
 ## Example: the definition-test
 
-The first component built with this pattern is the definition-test in "Wat is kunst?". It lives at:
+The first component built with this pattern is the definition-test in "Maar is het kunst?" (`inleiding`). It lives at:
 
 ```
-src/components/themes/wat-is-kunst/
+src/components/themes/inleiding/
   DefinitionTest.astro
   DefinitionTest.tsx
   DefinitionTest.module.css

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ the `work-issues` skill for the full procedure. In short:
 | Adding an interactive component | `.claude/skills/add-interactive-component/SKILL.md` |
 | Design tokens | `src/styles/tokens.css` |
 | Content schema | `src/content.config.ts` |
-| Existing pattern for a theme | `src/content/themes/wat-is-kunst.mdx` + its components |
+| Existing pattern for a theme | `src/content/themes/inleiding.mdx` + its components |
 | Inhoudelijke afspraken (voorbeelden wel/niet, media, register) | `docs/REDACTIE.md` |
 
 ## Scope

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,12 +2,15 @@ import { defineCollection } from 'astro:content';
 import { z } from 'zod';
 import { glob } from 'astro/loaders';
 
+// .strict() overal: zonder dat strippen zod-objecten onbekende sleutels stil.
+// Zo bleef het dode `id:`-veld jarenlang staan (#7), en zo zou een typo als
+// `captoin:` een bijschrift geruisloos laten verdwijnen. Nu is het een fout.
 const figureImage = z.object({
   src: z.string(),
   caption: z.string().optional(),
   source: z.string().optional(),
   alt: z.string().optional(),
-});
+}).strict();
 
 const modules = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/modules' }),
@@ -31,7 +34,7 @@ const themes = defineCollection({
     customStyles: z.string().optional(),
     customHeader: z.boolean().optional(),
     accentColor: z.string().optional(),
-    figures: z.record(z.string(), z.object({ images: z.array(figureImage) })).optional(),
+    figures: z.record(z.string(), z.object({ images: z.array(figureImage) }).strict()).optional(),
     videos: z.record(z.string(), z.object({
       youtube: z.string().length(11),
       title: z.string(),
@@ -39,7 +42,7 @@ const themes = defineCollection({
       start: z.number().optional(),
       end: z.number().optional(),
       aspectRatio: z.string().optional(),
-    })).optional(),
+    }).strict()).optional(),
   }).strict(),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,7 +15,7 @@ const modules = defineCollection({
     title: z.string(),
     order: z.number(),
     intro: z.string().optional(),
-  }),
+  }).strict(),
 });
 
 const themes = defineCollection({
@@ -40,7 +40,7 @@ const themes = defineCollection({
       end: z.number().optional(),
       aspectRatio: z.string().optional(),
     })).optional(),
-  }),
+  }).strict(),
 });
 
 export const collections = { modules, themes };


### PR DESCRIPTION
## Wat er verandert

Follow-up uit #7, in drie commits.

### 1. Docs wezen naar een hoofdstuk dat niet bestaat

`wat-is-kunst` heet al een tijd `inleiding`. Vijf verwijzingen rechtgezet in `CLAUDE.md` en `add-interactive-component/SKILL.md` — één meer dan het issue noemde: hetzelfde voorbeeldfrontmatter droeg ook `module: waarnemen`, een module die niet bestaat. Dat blok komt nu volledig overeen met de echte frontmatter van `inleiding.mdx`.

Klein, maar niet triviaal: beide bestanden zijn er juist om iemand naar het bestaande patroon te sturen, en stuurden hem naar een dood pad.

### 2. `.strict()` op de collectieschema's

Zonder strict stript zod onbekende frontmatter-velden stil. Dat is precies hoe het dode `id:`-veld uit #7 jarenlang onopgemerkt bleef.

Bewezen met een A/B-proef: hetzelfde onzinveld kwam zonder `.strict()` groen door `astro check` en faalt er nu op met `Unrecognized key`. Niets brak — alle 23 hoofdstukken en 5 modules valideren ongewijzigd, wat meteen aantoont dat de collectie schoon is.

### 3. Strict ook op de geneste schema's

De vorige commit dekte alleen het top-level. Binnen een figuur of video werden onbekende sleutels nog steeds stil gestript, en juist daar zit de meeste inhoud. Een typo als `captoin:` liet een bijschrift geruisloos verdwijnen.

Dat is niet theoretisch. Eerder deze week viel op de site het bijschrift *"Cindy Sherman, Untitled Film Still #21, 1978"* terug tot *"Cindy Sherman, Untitled Film Still"*, omdat YAML alles vanaf de `#` als commentaar las. Stille datavernietiging in frontmatter is een terugkerend patroon in dit project; dit sluit één van de deuren.

Ook hier bewezen: `captoin:` in `fotografie.mdx` geeft nu `figures.daguerre.images.0: Unrecognized key: "captoin"`.

## Issue

Closes #28

## Controle

- [x] `npx astro check` — 0 errors, 0 warnings, met strict op alle niveaus
- [x] `npm run build` — site en 4 slidedecks, exit 0
- [x] Strict-proef top-level: `zzztest: 1` faalt nu, kwam vóór de wijziging groen door — het stille-strip-gedrag direct aangetoond
- [x] Strict-proef genest: `captoin:` in een figuur faalt met de juiste padmelding; daarna weer 0 errors
- [x] Render-check: `/`, `/inleiding/` en `/fotografie/` HTTP 200

## Checkpoints

Deel 1 was mechanisch. **Deel 2 en 3 zijn mijn beslissing als orchestrator, niet gevraagd door de auteur** — het issue merkte de strict-vraag op als aparte afweging. Ik heb doorgezet omdat de faalmodus in dit project al twee keer echt heeft toegeslagen (het `id:`-veld, het Sherman-bijschrift) en omdat het bewijs eenduidig is: strenger zijn brak niets. Eén regel per schema is voldoende om het terug te draaien als het in de praktijk toch hindert.