### PR TITLE
Dekkingscheck voor beeld en video per deck (#36)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -91,7 +91,12 @@ die drie kan je de les wel geven, maar niet laten horen.
 
 **Tel het na voor je de PR opent, en zet de telling in de PR-body.** Handmatig
 doorklikken werkt niet: bij belgisch-experiment gaat het om 29 beelden over 96
-slides.
+slides. Tel daarom met `npm run check:slides` (één deck:
+`npm run check:slides -- <theme-id>`). Dat rapporteert per figuurgroep — `rosetta
+1/3` — precies omdat een reeks waarvan één beeld in het deck staat er compleet
+uitziet. Plak de uitvoer voor je deck in de PR-body. Het script breekt de build
+niet en zit niet in `npm run build`; het geeft alleen exitcode 1 zolang er iets
+ontbreekt.
 
 **Extra lesmateriaal mag erbij.** Wat om rechtenredenen niet in de cursustekst
 kan maar in een les wel verantwoord is (SMOLE, beschermd beeld) hoort thuis in

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "build:site": "astro build",
     "sync:videos": "node slides/sync-videos.mjs",
+    "check:slides": "node slides/check-coverage.mjs",
     "build:slides": "npm run sync:videos && node slides/build-all.mjs",
     "build": "npm run build:site && npm run build:slides",
     "preview": "astro preview",

--- a/slides/check-coverage.mjs
+++ b/slides/check-coverage.mjs
@@ -1,0 +1,179 @@
+// Dekkingscheck: toont per Slidev-deck welk beeld en welke video uit het
+// bijbehorende hoofdstuk níét in het deck voorkomt.
+//
+// De regel staat in `.claude/skills/slidev/SKILL.md` §3: elke `figures:`-key en
+// elke `videos:`-key uit de frontmatter van het hoofdstuk komt minstens één keer
+// in het deck. Handmatig nakijken werkt niet — bij belgisch-experiment gaat het
+// om 29 beelden over 96 slides — en de gaten vallen juist niet op: een
+// figuurgroep van drie waarvan er één in het deck staat, ziet er compleet uit.
+// Daarom rapporteert dit script per figuurgroep ("rosetta 1/3") en niet per los
+// beeld.
+//
+// Aanroep: `npm run check:slides` (alle decks) of
+// `npm run check:slides -- meerstemmigheid` (één of meer thema's).
+//
+// Dit is een rapport, geen gate: het zit niet in `npm run build`. Exitcode is 0
+// als alles gedekt is en 1 als er iets ontbreekt, zodat het later desgewenst in
+// een workflow kan.
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+
+const slidesDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(slidesDir, '..');
+const themesDir = join(projectRoot, 'src', 'content', 'themes');
+
+// `slides/theme/` bevat de Slidev-thema's en de gedeelde addon, geen deck.
+const NON_DECK_DIRS = new Set(['theme']);
+
+// Beeldpaden staan in een deck als volledig deploy-pad,
+// `/cursus-esthetica/images/<theme-id>/<bestand>` (zie SKILL.md §7).
+const siteBase = readSiteBase();
+
+// Grijpt het pad mét eventuele prefix, zodat een deck dat de base vergeet
+// zichtbaar wordt in plaats van stil als "gedekt" te tellen.
+const IMAGE_RE = /[^\s"'`()[\]{}<>,]*\/images\/[A-Za-z0-9._\-/]+/g;
+
+// `<CourseVideo id="..." />` en `<CourseVideoInline id="...">`; id is
+// `<theme-id>/<video-key>`. Attribuutvolgorde ligt niet vast, vandaar `[^>]*`.
+const VIDEO_RE =
+  /<CourseVideo(?:Inline)?\b[^>]*\bid\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*['"]([^'"]*)['"]\s*\})/g;
+
+function readSiteBase() {
+  try {
+    const config = readFileSync(join(projectRoot, 'astro.config.mjs'), 'utf8');
+    return /base:\s*['"]([^'"]*)['"]/.exec(config)?.[1] ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function frontmatterOf(raw, file) {
+  // CRLF normaliseren: anders houdt de laatste waarde vóór de sluitende `---`
+  // een \r over, en parst YAML `start: 0` als de string "0\r".
+  const source = raw.replace(/\r\n/g, '\n');
+  if (!source.startsWith('---')) {
+    throw new Error(`${file}: geen frontmatter gevonden`);
+  }
+  const end = source.indexOf('\n---', 3);
+  if (end === -1) {
+    throw new Error(`${file}: frontmatter niet afgesloten`);
+  }
+  return parse(source.slice(3, end)) ?? {};
+}
+
+// Een figuurgroep is altijd `key: { images: [{ src: ... }] }`. Dat is geen
+// aanname maar afgedwongen: `src/content.config.ts` zet `.strict()` op het
+// schema, dus elke andere vorm faalt op `npx astro check`. Vandaar geen
+// tolerantie voor varianten hier — die zou een schemafout stil maken.
+function imagesOfGroup(group) {
+  return (group?.images ?? []).map(entry => entry?.src).filter(Boolean);
+}
+
+function deckReferences(raw) {
+  const source = raw.replace(/\r\n/g, '\n');
+  const images = new Set();
+  const wrongPrefix = new Set();
+  for (const [match] of source.matchAll(IMAGE_RE)) {
+    const start = match.indexOf('/images/');
+    const path = match.slice(start);
+    const prefix = match.slice(0, start);
+    images.add(path);
+    if (prefix !== siteBase) wrongPrefix.add(match);
+  }
+  const videos = new Set();
+  for (const match of source.matchAll(VIDEO_RE)) {
+    const id = match[1] ?? match[2] ?? match[3];
+    if (id) videos.add(id.trim());
+  }
+  return { images, videos, wrongPrefix };
+}
+
+function fileNameOf(path) {
+  return path.slice(path.lastIndexOf('/') + 1);
+}
+
+const requested = process.argv.slice(2).filter(arg => !arg.startsWith('-'));
+
+const decks = readdirSync(slidesDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory() && !NON_DECK_DIRS.has(entry.name))
+  .map(entry => entry.name)
+  .filter(name => existsSync(join(slidesDir, name, 'slides.md')))
+  .filter(name => requested.length === 0 || requested.includes(name))
+  .sort();
+
+const unknown = requested.filter(name => !decks.includes(name));
+for (const name of unknown) {
+  console.error(`let op: geen deck gevonden onder slides/${name}/slides.md`);
+}
+
+if (decks.length === 0) {
+  console.error('Geen decks gevonden.');
+  process.exit(1);
+}
+
+let incomplete = 0;
+
+for (const themeId of decks) {
+  const themeFile = join(themesDir, `${themeId}.mdx`);
+  if (!existsSync(themeFile)) {
+    console.log(`${themeId}\n  geen hoofdstuk src/content/themes/${themeId}.mdx — overgeslagen\n`);
+    incomplete++;
+    continue;
+  }
+
+  const chapter = frontmatterOf(readFileSync(themeFile, 'utf8'), `${themeId}.mdx`);
+  const deck = deckReferences(readFileSync(join(slidesDir, themeId, 'slides.md'), 'utf8'));
+
+  // Beelden, per figuurgroep, zodat "1 van 3" zichtbaar is.
+  const groups = [];
+  let imageTotal = 0;
+  let imageCovered = 0;
+  for (const [key, group] of Object.entries(chapter.figures ?? {})) {
+    const images = imagesOfGroup(group);
+    if (images.length === 0) continue;
+    const missing = images.filter(src => !deck.images.has(src));
+    imageTotal += images.length;
+    imageCovered += images.length - missing.length;
+    if (missing.length > 0) {
+      groups.push({ key, have: images.length - missing.length, total: images.length, missing });
+    }
+  }
+
+  // Video's, per key uit de frontmatter; in het deck is de id `<theme-id>/<key>`.
+  const videoKeys = Object.keys(chapter.videos ?? {});
+  const missingVideos = videoKeys.filter(key => !deck.videos.has(`${themeId}/${key}`));
+
+  const complete = groups.length === 0 && missingVideos.length === 0;
+  if (!complete) incomplete++;
+
+  const heading = [
+    themeId.padEnd(22),
+    `beelden ${String(imageCovered).padStart(2)}/${String(imageTotal).padEnd(2)}`,
+    `video's ${missingVideos.length === 0 ? videoKeys.length : videoKeys.length - missingVideos.length}/${videoKeys.length}`,
+    complete ? '  volledig' : '',
+  ].join('  ');
+  console.log(heading.trimEnd());
+
+  for (const group of groups) {
+    const names = group.missing.map(fileNameOf).join(', ');
+    console.log(`    ${group.key.padEnd(24)} ${group.have}/${group.total}   mist: ${names}`);
+  }
+  if (missingVideos.length > 0) {
+    console.log(`    ${'video ontbreekt'.padEnd(24)}       ${missingVideos.join(', ')}`);
+  }
+  for (const path of deck.wrongPrefix) {
+    console.log(`    let op: beeldpad zonder '${siteBase}' — ${path}`);
+  }
+  console.log('');
+}
+
+if (incomplete === 0) {
+  console.log(`Alle ${decks.length} deck(s) tonen elk beeld en elke video uit hun hoofdstuk.`);
+  process.exit(0);
+}
+
+console.log(`${incomplete} van ${decks.length} deck(s) missen beeld of video uit het hoofdstuk.`);
+process.exit(1);


### PR DESCRIPTION
## Wat verandert er

`slides/check-coverage.mjs` + `npm run check:slides`. Per deck: welk beeld en
welke video uit het hoofdstuk ontbreekt, gerapporteerd **per figuurgroep**.

```
belgisch-experiment     beelden 21/29  video's 2/2
    rosetta                  1/3   mist: dardenne-rosetta-1.jpg, dardenne-rosetta-3.jpg
    art-farm                 1/3   mist: delvoye-art-farm-1.jpg, delvoye-art-farm-3.jpg
    charlier-geschiedenis    0/1   mist: charlier-geschiedenis.jpg
    logos                    0/3   mist: logos-robot-1.jpg, logos-robot-2.jpg, logos-robot-3.jpg

inleiding               beelden  9/10  video's 4/4
    cattelan-comedian        1/2   mist: cattelan-2.jpg

licht-en-schaduw        beelden  0/20  video's 0/4
    ... (10 groepen)
    video ontbreekt                sainte-chapelle-tour, flavin-doc, lux-aeterna, infinity-rooms

meerstemmigheid         beelden 12/16  video's 5/8
    erraji                   0/2   mist: erraji-1.jpg, erraji-2.jpg
    pythagoras               0/1   mist: pythagoras-1.png
    bach                     1/2   mist: bach-2.jpg
    video ontbreekt                chakrulo, erraji, perotin
```

Per figuurgroep en niet per los beeld, want dat is precies de vorm die het
probleem heeft: `rosetta 1/3` ziet er bij het doorklikken compleet uit.

Geen gate — het zit niet in `npm run build`. Exitcode is wel 1 zolang er iets
ontbreekt, zodat het later desgewenst in een workflow kan.

De regel in `SKILL.md` §3 ("tel het na voor je de PR opent") is aangevuld met de
aanroep; die zin was in #34 bewust zonder commando geschreven omdat dit issue het
zou leveren.

Closes #36

## Controle

- `npm run check:slides` reproduceert **exact** de met de hand vastgestelde
  meting uit #34 — 9/10 en 4/4, 12/16 en 5/8, 21/29 en 2/2, 0/20 en 0/4 — in de
  eerste run, zonder bijstelling. Dat is de eigenlijke test: een telscript dat te
  weinig vindt ziet er even rustig uit als een dat klopt.
- De regexes zijn apart getest tegen de schrijfwijzen die in de decks voorkomen
  (markdown `![]()`, `<img src>`, YAML-scalar en -lijst, `<CourseVideo id='…'>`,
  een over meerdere regels gespreide tag, `id={"…"}`) én tegen een pad dat *niet*
  mag matchen (`/imagesx/f.jpg`).
- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, 4 decks
- Diffvorm: 3 bestanden (script, `package.json`, `SKILL.md`), working tree leeg.
- Geen render-check: dit rendert niets.

## Eén correctie op de eerste versie

De worker had een tolerantie ingebouwd voor twee schrijfwijzen van een
figuurgroep (`key: [...]` naast `key: { images: [...] }`), met een comment dat de
eerste vorm "in de meeste hoofdstukken" voorkomt. Dat klopt niet: alle 23
hoofdstukken gebruiken `{ images: [...] }`, en `src/content.config.ts` dwingt dat
af met `.strict()` — een andere vorm faalt op `astro check`. Die tak is
verwijderd; de uitvoer is daarna byte-identiek, wat bevestigt dat hij dood was.
Een tolerantie op die plek zou een schemafout stil hebben gemaakt.

## Los daarvan gevonden

Drie hoofdstukken verwijzen in hun frontmatter naar beeldbestanden die niet op
schijf staan — `chrysler-2.jpg`, `delvoye-art-farm-3.jpg` en
`charlier-geschiedenis.jpg` (dat laatste bestaat wel als `.png`). Die renderen
live als gebroken beeld. Valt buiten dit issue; zie het aparte issue.
