### PR TITLE
Deck voor hoofdstuk 2: perspectief en ruimte (#35)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -80,7 +80,8 @@ waarvan één beeld in het deck staat, ziet er compleet uit. Alleen tellen vindt
 het.
 
 Dus: **een figuurgroep met meerdere beelden wordt niet tot één beeld
-gereduceerd.** `compare`, `paired-reveal` en `quadrants` bestaan precies daarvoor.
+gereduceerd.** `compare`, `triptych`, `paired-reveal` en `quadrants` bestaan
+precies daarvoor.
 Staan er drie beelden in de groep, dan is de vraag welke layout die drie draagt —
 niet welk beeld het beste is.
 
@@ -113,6 +114,7 @@ hoofdstuk, niet die van de vorige les.
 | `manifest` | inleiding |
 | `contrapunctus` | meerstemmigheid |
 | `aigles` | belgisch-experiment |
+| `oculus` | perspectief-en-ruimte |
 
 Een nieuw deck betekent normaal een nieuw thema onder `slides/theme/<naam>/`:
 
@@ -129,6 +131,13 @@ gedeelde layouts stil. Het contract staat in `slides/README.md` §
 *Tokens-contract voor nieuwe thema's* — minstens `--color-text`,
 `--color-text-quiet`, `--space-sm/md/lg/xl`, `--font-mono`, `--step--1`, plus
 optioneel `--color-rule`.
+
+`--color-rule` is optioneel in de code (`layouts.css` regels 31 en 83 schrijven
+`var(--color-rule, var(--color-text))`), maar bij een donker thema is die
+fallback een lichte rand rond elk quadrant en rond het paired-reveal-beeld. Zet
+hem daar dus altijd. In de praktijk bijt dit nu nergens — alle vier de bestaande
+thema's definiëren `--color-rule` al — maar het is de val die op je wacht zodra
+je hem vergeet.
 
 Startpunt voor de sfeer is de `accentColor` en het `customStyles`-bestand van het
 hoofdstuk zelf (`src/styles/themes/<theme-id>.css`). Het deck en de
@@ -147,6 +156,7 @@ Wat er nu is in `slides/theme/layouts-base/layouts/`:
 | `image` | één beeld, volle slide (`backgroundSize: contain` voor werken) |
 | `image-left` / `image-right` | beeld naast tekst |
 | `compare` | twee beelden naast elkaar, `left:` en `right:` |
+| `triptych` | drie (of twee/vier) beelden op één rij, `images:` + optioneel `captions:`, `reveal: true` voor één per klik |
 | `paired-reveal` | tekststappen links, wisselend beeld rechts — per klik het volgende beeld uit `images:` |
 | `quadrants` | vier vakken, `::q1::` t/m `::q4::` |
 
@@ -261,6 +271,16 @@ en klik het door:
 - speelt elk fragment, met de juiste starttijd;
 - klopt de dekkingstelling met de frontmatter van het hoofdstuk;
 - noemt de slotslide het juiste volgende hoofdstuk.
+
+**Die render-check vraagt een scherm.** Er is geen headless alternatief in dit
+project: `slidev export` heeft `playwright-chromium` nodig en dat zit niet in de
+dependencies (toevoegen is een aparte afweging, doe dat niet en passant). Werk je
+zonder scherm, dan sla je de check niet stil over — je meldt in de PR expliciet
+wat je wél en niet hebt kunnen vaststellen, en je toont per nieuwe layout en
+component bewijs uit de gebouwde bundel: een eigen chunk met de scoped klassen
+erin (`.triptych-panel`, `.vp-rays`) en nul `resolveComponent(...)` in `dist/`.
+Een niet-gevonden layout laat precies dat achterwege, dus het onderscheid is
+hard. Wat het níét bewijst is of het er goed uitziet; zeg dat er dan ook bij.
 
 Zet de echte uitkomsten in de PR-body, inclusief de telling vóór en na.
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -9,7 +9,7 @@ op dezelfde GitHub Pages-site als de cursus.
 ```
 slides/
   theme/
-    manifest/  contrapunctus/  aigles/   # één Slidev-thema per hoofdstuk
+    manifest/  contrapunctus/  aigles/  oculus/   # één Slidev-thema per hoofdstuk
     layouts-base/                        # gedeeld addon met extra layouts
   <theme-id>/slides.md            # één map per deck
   build-all.mjs                   # bouwt alle decks naar dist/slides/<id>/
@@ -20,7 +20,7 @@ slides/
 Elk hoofdstuk krijgt zijn **eigen visuele thema** onder `theme/` — het draagt de
 sfeer van dat hoofdstuk, niet die van de vorige les. Daarnaast trekt een deck het
 **`layouts-base`-addon** binnen voor de gedeelde extra layouts (`compare`,
-`paired-reveal`, `quadrants`) en de videocomponenten:
+`triptych`, `paired-reveal`, `quadrants`) en de videocomponenten:
 
 ```yaml
 ---

--- a/slides/perspectief-en-ruimte/slides.md
+++ b/slides/perspectief-en-ruimte/slides.md
@@ -1,0 +1,32 @@
+---
+theme: ../theme/oculus
+addons:
+  - ./theme/layouts-base
+title: Wie mag in het midden staan?
+info: |
+  Cursus Esthetica — hoofdstuk 02
+  Perspectief lijkt een techniek. Het is een beslissing over wie mag kijken,
+  wie gezien wordt, en wie onzichtbaar blijft.
+routerMode: hash
+---
+
+<div class="vp-marker" />
+<div class="vp-label">verdwijnpunt</div>
+
+# Wie mag in het <span style="color: var(--color-accent);">midden</span> staan?
+
+Perspectief lijkt een techniek. Het is een beslissing — over wie mag kijken, wie gezien wordt, en wie onzichtbaar blijft.
+
+<!--
+Tweede hoofdstuk. Begin niet bij de uitleg maar bij het raster op deze slide:
+laat de klas het even zien, en vraag waar de lijnen samenkomen. Iemand wijst het
+kruis aan. Zeg dan: dat punt is geen technisch gegeven, dat is een plaats waar
+iemand staat — en de rest van de les gaat over wie dat is.
+
+Twee dingen om vooraf te ontkrachten, want ze zitten er bij iedereen in:
+perspectief is géén vooruitgang (de middeleeuwers "konden" het niet minder), en
+perspectief is géén neutrale weergave van hoe je ziet.
+
+Houd deze vraag vast tot het einde: als het centrum uiteindelijk bij jou ligt,
+wat wordt er dan van je verwacht? Daar eindigen we, bij Abramović.
+-->

--- a/slides/perspectief-en-ruimte/slides.md
+++ b/slides/perspectief-en-ruimte/slides.md
@@ -30,3 +30,806 @@ perspectief is géén neutrale weergave van hoe je ziet.
 Houd deze vraag vast tot het einde: als het centrum uiteindelijk bij jou ligt,
 wat wordt er dan van je verwacht? Daar eindigen we, bij Abramović.
 -->
+
+---
+layout: section
+class: vp-center
+---
+
+# 1 — Wie staat in het midden?
+
+Perspectief als beslissing, niet als techniek
+
+<!--
+Eerste beweging. Het verdwijnpunt staat vanaf hier precies in het midden van elke
+slide — dat is de stand van zaken die de renaissance oplegt, en die we in
+beweging 3 zien barsten.
+
+Doel van dit blok: de klas laten voelen dat "grootte = macht" en "lijnen naar één
+punt" twee even coherente systemen zijn, en dat het tweede geen verbetering is
+van het eerste.
+-->
+
+---
+layout: image
+image: /cursus-esthetica/images/perspectief/maesta.png
+backgroundSize: contain
+---
+
+<!--
+Cimabue, Santa Trinità Maestà, rond 1290.
+
+Zeg nog niets. Laat twintig seconden vallen — echt tellen, het voelt lang.
+
+Vraag dan: wie is hier de belangrijkste, en hoe weet je dat? Het antwoord komt
+altijd vanzelf: ze is het grootst. Vraag door: staan die engelen kleiner omdat ze
+verder weg zijn? Nee. Ze staan boven en naast elkaar op dezelfde hoogte.
+
+Dit heet hiërarchisch perspectief. Dat is een eufemisme. Het werkelijke principe
+is simpeler, en dat staat op de volgende slide.
+-->
+
+---
+layout: center
+class: vp-center
+---
+
+<div style="font-family: var(--font-display); font-size: var(--step-6); letter-spacing: -0.03em;">
+grootte = macht
+</div>
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-serif); font-style: italic; font-size: var(--step-3); color: var(--color-accent);">
+geen tekortkoming — een andere waarheid
+</div>
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-mono); font-size: var(--step--1); letter-spacing: 0.22em; text-transform: uppercase; color: var(--color-text-quiet);">
+Grieken en Romeinen deden al aan optiek
+</div>
+
+<!--
+Hier komt de val waar iedereen in trapt: "die middeleeuwers kénden het lineair
+perspectief nog niet, ze konden niet beter."
+
+Feitelijk klopt dat, maar het is een luie lezing. Grieken en Romeinen waren al met
+optiek bezig; die kennis was niet onbereikbaar. Deze schilders hadden er geen
+behoefte aan. Waarom zou je de wereld tonen vanuit het oog van een toevallige
+sterveling? De waarheid is niet wat jij ziet vanaf waar je toevallig staat — de
+waarheid is hiërarchisch, en de afbeelding hoort dat te laten zien.
+
+Niet voorzeggen: laat eerst iemand de "ze konden niet beter"-lezing uitspreken,
+dán deze slide. Het werkt alleen als ze hem zelf hebben gezegd.
+-->
+
+---
+layout: vanishing-point
+image: /cursus-esthetica/images/inleiding/school-of-athens.png
+focus: [50, 45]
+rays: 18
+label: verdwijnpunt
+caption: Rafaël, De school van Athene, 1509–1511
+---
+
+<!--
+Twee eeuwen later. Rafaël, De school van Athene.
+
+Vraag eerst — en klik nog niet: als je de lijnen van de trappen, de gewelven en de
+tegelvloer doortrekt, waar komen ze dan samen? Laat iemand naar het scherm komen
+en het aanwijzen.
+
+[click] De stralen verschijnen.
+[click] De horizon: alles ligt op ooghoogte.
+[click] Het punt zelf — precies tussen de gezichten van Plato en Aristoteles.
+
+Dat is geen versiering, dat is een stelling. De nieuwe kunst zegt: de waarheid ligt
+op ooghoogte, in een ruimte die gehoorzaamt aan de wetten die jij, de kijker,
+herkent.
+
+Let op: in het inleidingshoofdstuk stond dit werk náást een middeleeuws icoon, om
+te laten zien dat ruimte een keuze is. Hier is Rafaël niet het voorbeeld maar het
+onderwerp. Als de klas het herkent: mooi, zeg dat het dezelfde afbeelding is en
+dat we er nu een andere vraag aan stellen.
+-->
+
+---
+layout: center
+class: vp-center
+---
+
+## Brunelleschi · Alberti
+
+<div style="margin-top: var(--space-md); font-family: var(--font-serif); font-size: var(--step-3); font-style: italic; color: var(--color-text);">
+Eén oog. Op één plek. Alles wijkt naar één punt.
+</div>
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-serif); font-size: var(--step-2); color: var(--color-text-muted); max-width: 46ch; margin-left: auto; margin-right: auto;">
+Geen technische vooruitgang — een wereldbeeld.
+</div>
+
+<div v-click style="margin-top: var(--space-md); font-family: var(--font-mono); font-size: var(--step--1); letter-spacing: 0.22em; text-transform: uppercase; color: var(--color-accent);">
+moderne wetenschap · lineaire tijd · de camera
+</div>
+
+<!--
+Brunelleschi vindt het uit, Alberti legt het theoretisch vast. Vanaf hier staat de
+menselijke waarnemer in het centrum van de werkelijkheid.
+
+Trek de lijn door: dezelfde denkbeweging zit onder de moderne wetenschap (één
+waarnemer die meet), onder de lineaire tijd, en uiteindelijk onder de camera — een
+apparaat dat letterlijk één oog op één plek is. Het fototoestel is geen uitvinding
+die het perspectief bevestigde; het is perspectief in messing en glas.
+
+Niet te lang bij stilstaan, dit is de brug naar de volgende slide — daar zit het
+punt.
+-->
+
+---
+layout: center
+class: vp-center
+---
+
+## Wiens oog, precies?
+
+<div style="margin-top: var(--space-md);">
+
+<v-clicks>
+
+- bedienden
+- boeren
+- vrouwen die niet heilig zijn
+- mensen met een andere huidskleur
+
+</v-clicks>
+
+</div>
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-serif); font-style: italic; font-size: var(--step-3); color: var(--color-accent);">
+kleiner · vager · weggelaten
+</div>
+
+<!--
+Dit is het punt van de hele eerste beweging, dus neem er tijd voor.
+
+In de praktijk is die ene kijker een rijke, westerse, meestal mannelijke kijker.
+Wie buiten dat frame valt, krijgt in renaissanceschilderijen een kleiner formaat,
+een vagere plek achteraan, of helemaal geen plek.
+
+Klik ze één voor één weg en laat de klas zelf aanvullen wie er nog ontbreekt.
+
+De formulering die je wil laten hangen: perspectief democratiseert de blik niet.
+Het centraliseert hem. Eén punt betekent per definitie dat er maar één plaats is
+waar het klopt.
+
+Terugkoppelen naar Cimabue: bij hem stond de macht ín het beeld, zichtbaar, in de
+maat van de figuren. Bij Rafaël staat de macht búiten het beeld, op de plek waar
+de kijker hoort te staan. Dat is niet minder macht — het is beter verstopt.
+-->
+
+---
+layout: section
+class: vp-low
+---
+
+# 2 — De truc voorbij de lijn
+
+Hoe de illusie gebouwd wordt
+
+<!--
+Tweede beweging. Het verdwijnpunt is naar beneden gezakt: we kijken vanaf hier
+omhoog, naar plafonds.
+
+Doel van dit blok: laten zien dat perspectief niet één techniek is maar twee
+(meetkunde én kleur), dat de barok er een sport van maakt, en dat de illusie op
+het hoogtepunt van haar kunnen meteen ook haar eigen zwakte toont — ze werkt maar
+vanaf één tegel.
+-->
+
+---
+layout: image-right
+image: /cursus-esthetica/images/inleiding/monalisa.png
+class: vp-low
+---
+
+## Atmosferisch perspectief
+
+Lijnen regelen de meetkunde.
+
+Maar de verte is **blauw, wazig, ijl** — kilometers atmosfeer die de kleur afzwakken voor ze je oog bereiken.
+
+<v-click>
+
+<div style="font-family: var(--font-serif); font-style: italic; font-size: var(--step-2); color: var(--color-accent); margin-top: var(--space-md);">
+Vijf keer de afstand,<br/>vijf keer zo blauw.
+</div>
+
+</v-click>
+
+<!--
+Belangrijk: wijs de bérgen aan, niet het gezicht. Zeg dat ook hardop — iedereen
+kijkt automatisch naar haar. Dek desnoods met je hand het gezicht af op het
+scherm.
+
+Achter de Mona Lisa ligt een landschap waar de bergen letterlijk verdampen in
+blauw. Leonardo noteerde in zijn schetsboek dat iets op vijf keer de afstand vijf
+keer zo blauw moet zijn. Niet omdat het mooi is — omdat het zo wérkt. Dit is een
+van die momenten waarop wetenschap en kunst niet naast elkaar staan maar hetzelfde
+zijn.
+
+Als de klas dit werk herkent uit het inleidingshoofdstuk: daar ging het over vorm
+en over wat je oog van een gezicht vraagt. Hier kijken we naar de natuurkunde
+achterin. Zelfde beeld, andere vraag.
+
+Kijk eens naar de verte op een heldere dag: bergen worden blauwgrijs. Iedereen
+heeft dat gezien; bijna niemand heeft het opgemerkt.
+-->
+
+---
+layout: image
+image: /cursus-esthetica/images/perspectief/pozzo-1.png
+backgroundSize: contain
+---
+
+<!--
+Andrea Pozzo, plafond van de Sint-Ignatiuskerk in Rome, 1685.
+
+Vraag vóór je iets uitlegt: wat is hier steen en wat is verf? Laat ze gokken, laat
+ze aanwijzen. Meestal wijst iemand de pilaren aan als "echt".
+
+Antwoord: alles boven de echte kroonlijst is verf. De pilaren die het plafond
+omhoog lijken te tillen, de heiligen in de wolken, de open hemel — allemaal
+geschilderd op een plat oppervlak.
+
+Het woord is trompe-l'œil: bedrieg het oog. Bezoekers in 1690 keken omhoog en zagen
+een koepel die er niet was.
+
+Hier werken beide perspectieven samen — lijnen én kleur. Dat is waarom het zo
+onheimelijk goed is.
+-->
+
+---
+layout: paired-reveal
+class: vp-low
+images:
+  - /cursus-esthetica/images/perspectief/pozzo-2.png
+  - /cursus-esthetica/images/perspectief/pozzo-3.png
+---
+
+## Er ligt een tegel op de vloer
+
+De illusie werkt vanaf **één punt**. Letterlijk één tegel.
+
+::steps::
+
+- Sta erop: een koepel, diep, rond, van steen.
+- Sta er twee meter naast: verwrongen, scheef, plat.
+
+::after::
+
+<v-click>
+
+<div style="margin-top: var(--space-md); font-family: var(--font-serif); font-style: italic; font-size: var(--step-2); color: var(--color-accent);">
+Wie daar niet staat, ziet de leugen.
+</div>
+
+</v-click>
+
+<!--
+Er is echt een markering op de kerkvloer die aangeeft waar je moet gaan staan. Dat
+detail is grappig en het is ook het hele punt.
+
+[click] Het beeld vanaf de juiste plek. Een koepel.
+[click] Het beeld ernaast. De schijnarchitectuur stort in.
+[click] De regel eronder.
+
+Dit is het absolute hoogtepunt van het renaissanceproject — één oog, één waarheid,
+tot in het extreme doorgevoerd. En precies daar begin je te voelen dat er iets mis
+is. Niet omdat de techniek faalt: ze slaagt te goed.
+
+Laat de vervolgvraag even hangen voor je doorklikt.
+-->
+
+---
+layout: center
+class: vp-low
+---
+
+<div style="font-family: var(--font-serif); font-style: italic; font-size: var(--step-5); line-height: 1.25; max-width: 20ch; margin-left: auto; margin-right: auto;">
+Waarom zou schoonheid maar vanaf één plek bestaan?
+</div>
+
+<!--
+Laat deze staan. Zeg niets. Tel tot vijf.
+
+Dit is het scharnier van de hele les: de vraag die de derde beweging veroorzaakt.
+Alles tot hier bouwde het ene standpunt op; alles hierna breekt het af.
+
+Als iemand antwoordt, ga er niet op in — zeg dat we het antwoord in het volgende
+kwartier gaan zien.
+-->
+
+---
+layout: image
+image: /cursus-esthetica/images/perspectief/riley-1.png
+backgroundSize: contain
+---
+
+<!--
+Bridget Riley, Movement in Squares, 1961. Vierhonderd jaar na Pozzo.
+
+Niets zeggen. Laat ze dertig seconden kijken.
+
+Vraag dan: wat beweegt er? Antwoord: niets. Er beweegt helemaal niets — het is inkt
+op papier, volstrekt stil.
+
+De beweging gebeurt in hun ogen. Op-art heeft geen verdwijnpunt meer; de illusie
+zit niet ín het beeld maar in de kijker. Het netvlies doet mee.
+
+Waarschuw wie snel misselijk wordt of migraine krijgt dat ze even weg mogen kijken.
+Dat is geen grap bij Riley.
+-->
+
+---
+layout: compare
+left: /cursus-esthetica/images/perspectief/riley-2.png
+right: /cursus-esthetica/images/perspectief/riley-3.png
+---
+
+<!--
+Links: Fall, 1963. Rechts: Hesitate, 1964.
+
+Bij Fall: vraag of ze kleuren zien. Veel mensen zien er kleur in — die is er niet.
+Zwart en wit, verder niets. De kleur ontstaat in het oog, niet op het doek.
+
+Bij Hesitate: de vlakken lijken dieper te liggen dan het doek. Ook dat is geen
+perspectiefconstructie; er is geen enkele lijn die ergens naartoe loopt.
+
+De les van deze twee slides: het centrum van het perspectief is aan het verschuiven
+van het doek naar de kijker. Riley bouwt geen ruimte meer — ze bespeelt jouw
+fysiologie. Dat is de brug naar de laatste beweging, waar je uiteindelijk zelf in
+het werk staat. Zeg dat er nu al bij, dan valt het straks op zijn plaats.
+-->
+
+---
+layout: section
+class: vp-scattered
+---
+
+# 3 — Het centrum barst
+
+De moderne breuk
+
+<!--
+Derde beweging. Kijk even naar de achtergrond van deze slide: het raster komt niet
+meer op één punt samen, het ligt in drie brokken uiteen. Dat is geen decoratie —
+dat is precies wat er in dit blok gebeurt. Wijs het aan als je wil.
+
+Doel: laten zien dat het opgeven van het ene standpunt geen verlies is maar een
+stelling, en dat er in hetzelfde jaar nog iemand anders veel verder ging dan
+Picasso — en dat we haar naam pas honderd jaar later leerden.
+-->
+
+---
+layout: image
+image: /cursus-esthetica/images/perspectief/demoiselles.png
+backgroundSize: contain
+---
+
+<!--
+Picasso, Les Demoiselles d'Avignon, 1907.
+
+Geen inleiding. Vraag meteen: wat klopt er niet? Laat ze opsommen, schrijf desnoods
+mee. Ze vinden het zelf allemaal.
+
+Wat er meestal komt: gezichten van voren én van opzij tegelijk. Lichamen in
+scherven. Geen diepte, geen vloer, geen achtergrond die achter iets ligt. Twee
+gezichten die op maskers lijken.
+
+Tijdgenoten vonden het onleesbaar. Matisse lachte erom. Het doek stond jaren
+opgerold in Picasso's atelier.
+-->
+
+---
+layout: center
+class: vp-scattered
+---
+
+> Picasso heeft petroleum gedronken om vuur te spuwen.
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-mono); font-size: var(--step--1); letter-spacing: 0.22em; text-transform: uppercase; color: var(--color-text-quiet);">
+Georges Braque, 1907
+</div>
+
+<!--
+Braque zei dit toen hij het doek voor het eerst zag. Hij bedoelde het niet
+vriendelijk.
+
+Kleine pointe die de moeite waard is: dezelfde Braque bouwt binnen twee jaar mét
+Picasso het kubisme op. De felste criticus wordt de mede-uitvinder. Dat gebeurt
+vaker dan je denkt bij een breuk — de mensen die het hardst reageren, zijn de
+mensen die het scherpst gezien hebben dat er iets aan de hand is.
+-->
+
+---
+layout: center
+class: vp-scattered
+---
+
+## Picasso weigert te kiezen
+
+<div style="margin-top: var(--space-md);">
+
+<v-clicks>
+
+- je oog beweegt
+- je loopt rond een gitaar
+- je wéét hoe de achterkant eruitziet
+- dus schilder je ze allemaal — tegelijk
+
+</v-clicks>
+
+</div>
+
+<div v-click style="margin-top: var(--space-lg); font-family: var(--font-serif); font-style: italic; font-size: var(--step-3); color: var(--color-accent);">
+de eerste democratische ruimte in de westerse kunst
+</div>
+
+<!--
+Het lineair perspectief had de wereld platgeslagen tot wat één oog, vanaf één plek,
+op één moment kan zien. Het kubisme zegt: dat is een leugen. Een eerlijk schilderij
+laat meespelen wat je wéét, niet alleen wat je vanaf één stoel ziet.
+
+De politieke lezing, als je die wil maken — en ze is hier verdedigbaar: er is geen
+geprivilegieerd standpunt meer. Geen koning, geen mecenas, geen centrale kijker voor
+wie de scène geregisseerd is. De ruimte wordt verdeeld.
+
+Niet toevallig gebeurt dat precies wanneer Europa op zijn kop staat: Einstein zegt
+in 1905 dat zelfs tijd afhangt van waar je staat, de koloniale orde kraakt, en
+beelden uit Afrika en Oceanië tonen Picasso en Braque dat er beeldtradities bestaan
+die nooit aan lineair perspectief hebben gedaan en prima functioneren.
+
+Dat laatste eerlijk brengen: Picasso keek naar die maskers zonder één moment te
+vragen wie ze gemaakt had of waarvoor ze dienden. De bevrijding van de westerse
+ruimte is voor een deel gehaald uit culturen die daar zelf niets aan hadden.
+-->
+
+---
+layout: triptych
+captions:
+  - installatiezicht — Moderna Museet
+  - De tio största, nr 7, 1907
+  - De tio största, nr 1, 1907
+images:
+  - /cursus-esthetica/images/perspectief/klint-1.png
+  - /cursus-esthetica/images/perspectief/klint-2.png
+  - /cursus-esthetica/images/perspectief/klint-3.png
+---
+
+## Hilma af Klint · 1907
+
+<!--
+Vraag eerst: wie heeft ooit van haar gehoord? Meestal niemand. Laat die stilte
+even hangen — die is het punt van de volgende slide.
+
+Hetzelfde jaar als de Demoiselles. In Stockholm, in stilte, schildert Hilma af
+Klint De Tien Grootsten: doeken van bijna drie meter hoog.
+
+Het linkerbeeld is een installatiezicht, en dat staat er met opzet bij — zonder de
+zaal en de mensen erin geloof je de schaal niet. Wijs het aan.
+
+Wat er níét is: geen voorgrond, geen achtergrond, geen wereld die wordt afgebeeld.
+Geen herkenbaar object. Alleen verf die zichzelf is.
+
+Vergelijk hardop met Picasso: hij breekt het perspectief open maar schildert nog
+altijd vijf vrouwen in een kamer. Zij laat het onderwerp helemaal vallen. Dit is
+abstract, drie jaar vóór Kandinsky.
+-->
+
+---
+layout: center
+class: vp-scattered
+---
+
+## Je hebt nooit van haar gehoord
+
+<div style="margin-top: var(--space-md); font-family: var(--font-mono); font-size: var(--step-1); line-height: 2; color: var(--color-text-muted); text-align: left; display: inline-block;">
+
+<div v-click><span style="color: var(--color-accent);">1907</span> &nbsp; De tio största</div>
+<div v-click><span style="color: var(--color-accent);">1910</span> &nbsp; Kandinsky — "de eerste abstracte aquarel"</div>
+<div v-click><span style="color: var(--color-accent);">1917</span> &nbsp; Mondriaan — "de eerste compositie"</div>
+<div v-click><span style="color: var(--color-accent);">1944</span> &nbsp; af Klint sterft · werk 20 jaar verzegeld</div>
+<div v-click><span style="color: var(--color-accent);">2018</span> &nbsp; Guggenheim · de wereld kijkt op</div>
+
+</div>
+
+<!--
+Af Klint werkte geleid door wat ze beschreef als boodschappen uit seances en
+theosofische visioenen. Ze bepaalde zelf dat haar werk pas twintig jaar na haar
+dood getoond mocht worden — de wereld was er niet klaar voor, schreef ze.
+
+De wereld was er daarna ook niet klaar voor. Haar doeken lagen opgerold in een
+Zweedse opslagruimte terwijl Kandinsky en Mondriaan de uitvinders van de abstractie
+werden genoemd. Pas het retrospectief in het Guggenheim in 2018 maakte haar echt
+zichtbaar.
+
+Het punt dat blijft hangen: een canon is een keuze, geen natuurwet. Ze was er
+eerst; de anderen kregen de titel. Sindsdien moet de geschiedenis van de moderne
+kunst herschreven worden — en dat gaat traag, want een handboek herschrijven kost
+meer moeite dan er een voetnoot in zetten.
+
+Als je het meerstemmigheidshoofdstuk al gaf: dit is hetzelfde mechanisme als Bach
+die honderd jaar vergeten was tot Mendelssohn hem opnieuw uitvoerde.
+-->
+
+---
+layout: triptych
+captions:
+  - Iris van Herpen
+  - Iris van Herpen
+  - Look 16
+images:
+  - /cursus-esthetica/images/perspectief/herpen-1.png
+  - /cursus-esthetica/images/perspectief/herpen-2.png
+  - /cursus-esthetica/images/perspectief/herpen-3.png
+---
+
+## En vandaag
+
+<!--
+Iris van Herpen. Geen jurken die een lichaam volgen — sculpturen die eromheen
+bestaan, geprint uit materialen die niet zouden mogen bestaan.
+
+Vraag: waar is de voorkant? Bij een klassiek kledingstuk weet je meteen hoe je
+ervoor moet staan. Hier niet. Deze vormen hertekenen de ruimte in plaats van ze te
+respecteren — dat is precies wat Picasso met het doek deed, maar dan om een echt
+lichaam heen.
+
+De les van deze slide: de breuk met perspectief is geen eenmalige revolutie uit
+1907. Het is een terugkerende houding. Elke generatie beslist opnieuw of ze de
+regels van de ruimte aanvaardt of herschrijft — en wie daarbij gehoord wordt.
+
+Dat laatste is de brug naar de vierde beweging. Tot hier ging het over wie er in
+het beeld mag staan. Nu gaat het over jou.
+-->
+
+---
+layout: section
+class: glow
+---
+
+# 4 — Jij staat erin
+
+De kijker wordt deel van het werk
+
+<!--
+Vierde beweging. Het raster is weg — er is geen constructie meer, alleen licht dat
+van onderop opkomt. Vanaf hier bouwt niemand nog een ruimte vóór je.
+
+Dit is het blok waarin het deck iets moet doen wat de cursustekst niet kan: de klas
+ís op dit moment de kijker in de zaal. Ga langzamer dan je gewend bent. Laat
+stiltes vallen. Als je één beweging moet inkorten, kort dan beweging 2 in en niet
+deze.
+-->
+
+---
+layout: center
+class: glow
+---
+
+<div style="font-family: var(--font-serif); font-size: var(--step-4); color: var(--color-text-muted);">
+Tot hier stond je ervoor.
+</div>
+
+<div v-click style="margin-top: var(--space-md); font-family: var(--font-display); font-size: var(--step-6); letter-spacing: -0.03em; color: var(--color-text);">
+Nu stap je erin.
+</div>
+
+<!--
+Zelfs toen het centrum barstte, stond je er nog steeds voor. Buiten. Als kijker.
+
+Er is een laatste beweging waarin die muur valt: de kunst houdt op een object te
+zijn dat je bekijkt en wordt een ruimte waar je binnenstapt.
+
+Kort houden, dit is een scharnier en geen halte.
+-->
+
+---
+layout: triptych
+captions:
+  - Black in Deep Red, 1957
+  - Red on Maroon, 1959
+  - No. 14, 1960
+images:
+  - /cursus-esthetica/images/perspectief/rothko-1.png
+  - /cursus-esthetica/images/perspectief/rothko-2.png
+  - /cursus-esthetica/images/perspectief/rothko-3.png
+---
+
+## Mark Rothko
+
+<!--
+Zeg hardop wat er mis is met deze slide. Dat is geen bescheidenheid, dat is de les:
+dit is precies wat Rothko verbood. Kleine reproducties, fel projectielicht, drie
+naast elkaar, en de klas op zes meter afstand. Op een scherm zijn dit gewoon vage
+rechthoeken en denk je: oké, kleurvlakken.
+
+Rothko eiste gedempt licht, doeken dicht bij elkaar, stille ruimtes waar mensen
+konden zitten. Zijn werken zijn enorm — drie meter soms. Sta er fysiek voor en de
+kleuren beginnen te gloeien; je perifere zicht vult zich met rood of zwart. Je
+voelt dat je ín het schilderij staat, niet ervoor.
+
+Zijn eigen zin, en hij meende die letterlijk: de mensen die huilen voor mijn
+schilderijen, hebben dezelfde religieuze ervaring als ik had toen ik ze schilderde.
+
+Als er ooit een museumbezoek in zit: dit is het werk waarvoor je gaat. Vertel dat
+ook zo — een reproductie van Rothko is een menukaart, geen maaltijd.
+-->
+
+---
+layout: breathe
+captions:
+  - James Turrell · Skyspace · Tremenheere Sculpture Garden
+  - James Turrell · Skyspace · Rocky Mountains
+  - James Turrell · Skyspace · Houston
+images:
+  - /cursus-esthetica/images/perspectief/skyspace-1.png
+  - /cursus-esthetica/images/perspectief/skyspace-2.png
+  - /cursus-esthetica/images/perspectief/skyspace-3.png
+---
+
+<!--
+James Turrell, Skyspaces. Een kamer met een rechthoekig gat in het plafond. Meer
+niet.
+
+Dim het licht in het lokaal als dat kan. De achtergrond van deze slide verschuift
+traag van donker naar warmrood — dat is opzet, en het is ongeveer een duizendste
+van wat er in een echte Skyspace gebeurt.
+
+[click] Tweede locatie. [click] Derde.
+
+Je gaat liggen of zitten en kijkt omhoog. Langzaam verschuift de kleur van het
+licht in de kamer, en daardoor verschuift je waarneming van het gat. Soms lijkt de
+lucht vlak — een geschilderde rechthoek. Soms oneindig diep. Soms een kleur die de
+lucht niet kán zijn.
+
+De vraag aan de klas, en laat ze even echt nadenken: waar is het kunstwerk? Niet het
+gat — dat is een gat. Niet de kamer, niet de lucht, niet het licht. Het kunstwerk is
+wat er in jouw hoofd gebeurt. Dat is het verste punt van deze hele les: het werk
+heeft geen kijker meer nodig, het bestáát uit een kijker.
+-->
+
+---
+layout: center
+class: glow
+---
+
+## De vierde wand
+
+<div style="margin-top: var(--space-md); font-family: var(--font-serif); font-size: var(--step-2); color: var(--color-text-muted); max-width: 44ch; margin-left: auto; margin-right: auto;">
+De onzichtbare muur tussen acteurs en publiek — de afspraak dat jij kijkt en zij spelen alsof je er niet bent.
+</div>
+
+<div style="margin-top: var(--space-lg); display: flex; gap: var(--space-xl); justify-content: center; font-size: var(--step-2);">
+<CourseVideo id="perspectief-en-ruimte/fleabag" label="Fleabag — televisie" />
+<CourseVideo id="perspectief-en-ruimte/deadpool" label="Deadpool — film" />
+</div>
+
+<!--
+Brecht brak die wand opzettelijk door zijn acteurs jou te laten aanspreken — niet
+om leuk te doen, maar om te verhinderen dat je je verliest in het verhaal. Hij wilde
+dat je bleef nadenken.
+
+Speel eerst Fleabag (0:00–0:50). Vraag daarna: wat verandert er als ze naar de
+camera kijkt? Het antwoord dat je zoekt: je bent van getuige medeplichtige geworden.
+Ze deelt iets met jou dat de andere personages niet weten.
+
+Dan Deadpool (0:00–0:40). Zelfde truc, ander effect: hier is het een grap, en het
+maakt de film lichter in plaats van ongemakkelijker. Vraag waarom dat verschilt.
+
+Houd dit blok kort en luchtig — het is de opwarming voor de volgende slide, en daar
+mag geen lach meer bij.
+-->
+
+---
+layout: center
+class: glow
+---
+
+## The Artist is Present
+
+<div style="margin-top: var(--space-md); font-family: var(--font-mono); font-size: var(--step-1); letter-spacing: 0.16em; color: var(--color-text-quiet);">
+MoMA · 2010 · 736 uur
+</div>
+
+<div style="margin-top: var(--space-lg); font-size: var(--step-2);">
+<CourseVideo id="perspectief-en-ruimte/abramovic" label="Marina & Ulay @ MoMA" />
+</div>
+
+<!--
+Zeg vóór je speelt alleen dit, en niet meer: Marina Abramović zit 736 uur stil in
+het MoMA. Bezoekers mogen één voor één tegenover haar gaan zitten en haar aankijken,
+zo lang ze willen. Geen performance, geen script. De man die zo meteen gaat zitten
+is Ulay, haar voormalige levenspartner. Ze had hem niet verwacht.
+
+Praat niet tijdens het fragment. Echt niet.
+
+Laat na afloop de stilte vallen. Tel voor jezelf hoe lang het duurt voor iemand iets
+zegt — meestal langer dan je durft. Breek die stilte niet zelf.
+
+Als er dan iets gezegd wordt, is de enige vraag die je nog nodig hebt: waar is hier
+het kunstwerk? Er is geen object, geen doek, geen zaal die telt. Er is de blik tussen
+twee mensen in een kamer. Verder niets.
+
+Dit is het eindpunt van de reeks die bij Cimabue begon.
+-->
+
+---
+layout: center
+class: glow
+---
+
+## Wie mag de ruimte bewonen?
+
+<div style="margin-top: var(--space-md); font-family: var(--font-serif); font-size: var(--step-2); line-height: 2.1; text-align: left; display: inline-block; color: var(--color-text-muted);">
+
+<div v-click>het icoon &nbsp;·&nbsp; <span style="color: var(--color-text);">God</span></div>
+<div v-click>de renaissance &nbsp;·&nbsp; <span style="color: var(--color-text);">de kijker met één oog</span></div>
+<div v-click>het kubisme &nbsp;·&nbsp; <span style="color: var(--color-text);">alle standpunten tegelijk</span></div>
+<div v-click>de abstractie &nbsp;·&nbsp; <span style="color: var(--color-text);">niemand</span></div>
+<div v-click style="font-size: var(--step-4); font-family: var(--font-display); color: var(--color-accent); padding-top: var(--space-sm);">de zaal &nbsp;·&nbsp; jij</div>
+
+</div>
+
+<!--
+De hele les in één vraag. Klik ze traag door en laat de klas telkens even
+meedenken — ze kunnen dit nu zelf invullen, dus vraag het ook: en daarna?
+
+Eerst alleen God. Dan de renaissancekijker met zijn ene oog. Dan de kubist met zijn
+veelheid aan standpunten. Dan niemand: de abstracte schilder die zegt dat de ruimte
+een leugen is. En ten slotte jij — niet als toeschouwer maar als mede-aanwezige.
+
+De vraag waarmee we bij het icoon begonnen — wie krijgt het centrum — is omgedraaid.
+Het centrum is nu waar jij staat.
+-->
+
+---
+layout: center
+class: glow
+---
+
+<div style="font-family: var(--font-serif); font-size: var(--step-2); line-height: 2.2; color: var(--color-text-muted);">
+
+<div v-click>in de middeleeuwen hoefde je te <span style="color: var(--color-text);">knielen</span></div>
+<div v-click>voor Rafaël mocht je <span style="color: var(--color-text);">bewonderen</span></div>
+<div v-click>voor Picasso moest je <span style="color: var(--color-text);">leren kijken</span></div>
+<div v-click style="font-size: var(--step-4); font-family: var(--font-display); color: var(--color-accent); padding-top: var(--space-md);">voor Abramović moet je komen opdagen</div>
+
+</div>
+
+<!--
+Slotgedachte, en de enige plek waar je een beetje mag doordrukken.
+
+Dat het centrum bij jou ligt, klinkt als een overwinning. Misschien is het dat ook.
+Maar het legt een last bij je. Elke stap in deze les vraagt méér van de kijker, niet
+minder.
+
+Voor Rothko, Turrell en Abramović moet je je laten aanspreken. Echt aanwezig zijn.
+Niet snel doorscrollen. De ruimte is niet langer iets dat de kunstenaar voor je
+bouwt — ze bestaat alleen als jij komt opdagen.
+
+Vraag voor thuis: zoek een kunstwerk op waarvan je denkt dat een foto ervan niet
+volstaat, en probeer op te schrijven wát er precies wegvalt. Dat is meteen de brug
+naar het volgende hoofdstuk, waar licht zelf het materiaal wordt.
+-->
+
+---
+layout: end
+---
+
+# Volgende keer
+
+*Wanneer wordt licht zelf het werk?*
+
+<!--
+Hoofdstuk 03, licht en schaduw. Als bruggetje: Turrell zat in deze les nog onder
+"ruimte", maar hij hoort net zo goed in de volgende — daar gaat het niet meer over
+waar je staat, maar over waar het licht vandaan komt.
+-->

--- a/slides/perspectief-en-ruimte/vite.config.ts
+++ b/slides/perspectief-en-ruimte/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { siteAssetsPlugin } from '../theme/dev-site-public';
+
+export default defineConfig({
+  plugins: [siteAssetsPlugin()],
+});

--- a/slides/theme/layouts-base/layouts/triptych.vue
+++ b/slides/theme/layouts-base/layouts/triptych.vue
@@ -1,0 +1,73 @@
+<!--
+  Drie beelden naast elkaar, elk volledig in beeld, met een optioneel
+  bijschrift per beeld.
+
+  Bestaat omdat `compare` er precies twee doet, `quadrants` een tekstgrid is en
+  `paired-reveal` er één tegelijk toont. Figuurgroepen van drie zijn de plek
+  waar de dekking in de bestaande decks lekte: wie een groep van drie over twee
+  slides moet splitsen, laat er in de praktijk één vallen (zie SKILL.md §3).
+
+  Gebruik:
+    ---
+    layout: triptych
+    images:
+      - /cursus-esthetica/images/perspectief/klint-1.png
+      - /cursus-esthetica/images/perspectief/klint-2.png
+      - /cursus-esthetica/images/perspectief/klint-3.png
+    captions: [installatiezicht, 'nr 7', 'nr 1']   # optioneel
+    reveal: true                                   # optioneel: één per klik
+    ---
+
+    ## Optionele titel
+
+  Werkt met twee, drie of vier beelden — de rij verdeelt de breedte gelijk.
+  `captions` mag korter zijn dan `images`; ontbrekende bijschriften blijven leeg.
+-->
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import { resolveAsset } from '../utils'
+
+const props = withDefaults(
+  defineProps<{
+    images?: string[]
+    captions?: string[]
+    reveal?: boolean
+  }>(),
+  { images: () => [], captions: () => [], reveal: false },
+)
+
+const slots = useSlots()
+const hasHeader = computed(() => !!slots.default)
+
+const panels = computed(() =>
+  props.images.map((src, i) => ({
+    src: resolveAsset(src),
+    caption: props.captions[i] ?? '',
+  })),
+)
+</script>
+
+<template>
+  <div class="slidev-layout triptych" :class="{ 'triptych--headed': hasHeader }">
+    <header v-if="hasHeader" class="triptych-header">
+      <slot />
+    </header>
+    <!-- Twee takken in plaats van een dynamische directive: `v-click` kent geen
+         waarde die hem uitschakelt, dus een `reveal ? … : false` zou stil elke
+         paneel-klik aanzetten. -->
+    <div class="triptych-row" :style="{ '--triptych-count': panels.length }">
+      <template v-if="reveal">
+        <figure v-for="(panel, i) in panels" :key="i" class="triptych-panel" v-click>
+          <img :src="panel.src" :alt="panel.caption" />
+          <figcaption v-if="panel.caption">{{ panel.caption }}</figcaption>
+        </figure>
+      </template>
+      <template v-else>
+        <figure v-for="(panel, i) in panels" :key="i" class="triptych-panel">
+          <img :src="panel.src" :alt="panel.caption" />
+          <figcaption v-if="panel.caption">{{ panel.caption }}</figcaption>
+        </figure>
+      </template>
+    </div>
+  </div>
+</template>

--- a/slides/theme/layouts-base/styles/layouts.css
+++ b/slides/theme/layouts-base/styles/layouts.css
@@ -44,6 +44,51 @@
   margin-top: var(--space-sm);
 }
 
+/* ── TRIPTYCH — drie (of twee/vier) beelden op één rij, optioneel met
+     titel erboven en een bijschrift per beeld ─────────────────────── */
+.slidev-layout.triptych {
+  display: grid;
+  grid-template-rows: 1fr;
+  gap: var(--space-lg);
+  padding: var(--space-lg) var(--space-md);
+}
+.slidev-layout.triptych.triptych--headed {
+  grid-template-rows: auto 1fr;
+}
+.slidev-layout.triptych .triptych-header h2 {
+  margin-bottom: 0;
+}
+.slidev-layout.triptych .triptych-row {
+  display: grid;
+  grid-template-columns: repeat(var(--triptych-count, 3), 1fr);
+  gap: var(--space-md);
+  min-height: 0;
+}
+.slidev-layout.triptych .triptych-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  margin: 0;
+  min-width: 0;
+  min-height: 0;
+}
+.slidev-layout.triptych .triptych-panel img {
+  max-width: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+  object-fit: contain;
+}
+.slidev-layout.triptych .triptych-panel figcaption {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  color: var(--color-text-quiet);
+  text-align: center;
+  line-height: 1.4;
+}
+
 /* ── COMPARE — twee afbeeldingen naast elkaar, zonder titel ───────── */
 .slidev-layout.compare {
   display: grid;

--- a/slides/theme/layouts-base/videos.generated.json
+++ b/slides/theme/layouts-base/videos.generated.json
@@ -335,6 +335,13 @@
     "start": 0,
     "end": 40
   },
+  "perspectief-en-ruimte/fleabag": {
+    "youtube": "i3tnMesJSGk",
+    "title": "Fleabag's Most Iconic Wall Breaks",
+    "source": "BBC",
+    "start": 0,
+    "end": 50
+  },
   "perspectief-en-ruimte/abramovic": {
     "youtube": "xlf68X2qEpM",
     "title": "Marina & Ulay @ MoMA (The Artist is Present)",

--- a/slides/theme/oculus/layouts/breathe.vue
+++ b/slides/theme/oculus/layouts/breathe.vue
@@ -1,0 +1,124 @@
+<!--
+  Beeld over de volle slide, zonder chroom, op een achtergrond die traag van
+  donker naar warmrood ademt — dezelfde curve als `skyspace-breathe` in
+  `src/styles/themes/perspectief-en-ruimte.css`, zodat het deck en de
+  hoofdstukpagina in beweging 4 hetzelfde doen.
+
+  Bestaat voor de laatste beweging van hoofdstuk 02, waar het hoofdstuk beweert
+  dat het werk een ruimte is waar je in staat. Een Skyspace als drie kleine
+  rechthoekjes naast elkaar is precies het tegendeel; hier vult één opening het
+  beeld en verschuift de kleur van de kamer eromheen. `image` geeft wel
+  full-bleed maar geen adem, geen wisseling per klik en geen uitgesteld
+  bijschrift.
+
+  Gebruik:
+    ---
+    layout: breathe
+    images:
+      - /cursus-esthetica/images/perspectief/skyspace-1.png
+      - /cursus-esthetica/images/perspectief/skyspace-2.png
+    captions: ['Tremenheere', 'Rocky Mountains']   # optioneel
+    ---
+
+  Het eerste beeld staat er meteen; elke klik schuift naar het volgende.
+  Respecteert `prefers-reduced-motion`: dan staat de achtergrond stil.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSlideContext } from '@slidev/client'
+import { resolveAsset } from '../../layouts-base/utils'
+
+const props = withDefaults(
+  defineProps<{
+    images?: string[]
+    captions?: string[]
+  }>(),
+  { images: () => [], captions: () => [] },
+)
+
+const { $clicks } = useSlideContext()
+
+const resolved = computed(() => props.images.map(resolveAsset))
+
+const index = computed(() => {
+  const n = resolved.value.length
+  if (n === 0) return -1
+  return Math.min(Math.max($clicks.value, 0), n - 1)
+})
+
+const caption = computed(() => props.captions[index.value] ?? '')
+</script>
+
+<template>
+  <div class="slidev-layout breathe">
+    <div class="breathe-stage">
+      <img
+        v-for="(image, i) in resolved"
+        :key="i"
+        :src="image"
+        :alt="captions[i] ?? ''"
+        :class="{ 'is-visible': i === index }"
+      />
+    </div>
+    <figcaption v-if="caption" class="breathe-caption">{{ caption }}</figcaption>
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.slidev-layout.breathe {
+  padding: 0;
+  position: relative;
+  overflow: hidden;
+  background: var(--color-bg);
+}
+
+@keyframes oculus-breathe {
+  0%   { background-color: #131417; }
+  33%  { background-color: #3d2b2b; }
+  66%  { background-color: #471c1c; }
+  100% { background-color: #6e2626; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .slidev-layout.breathe {
+    animation: oculus-breathe 75s ease-in-out alternate infinite;
+  }
+}
+
+.breathe-stage {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.breathe-stage img {
+  position: absolute;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  opacity: 0;
+  transition: opacity 900ms ease-in-out;
+}
+
+.breathe-stage img.is-visible {
+  opacity: 1;
+}
+
+.breathe-caption {
+  position: absolute;
+  left: var(--space-lg);
+  bottom: var(--space-lg);
+  z-index: 2;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.8);
+}
+</style>

--- a/slides/theme/oculus/layouts/vanishing-point.vue
+++ b/slides/theme/oculus/layouts/vanishing-point.vue
@@ -1,0 +1,204 @@
+<!--
+  Eén beeld, volledig in beeld, met een perspectiefconstructie die er op klik
+  overheen wordt getekend: haarlijnen die samenkomen op een instelbaar punt,
+  een horizon door dat punt, en een kruis op het punt zelf.
+
+  Bestaat omdat het hoofdstuk er letterlijk om vraagt — "trek de lijnen van de
+  trappen en de gewelven door: ze komen allemaal samen op één punt" — en omdat
+  geen van de gedeelde layouts iets over een beeld heen kan leggen: `compare`,
+  `paired-reveal` en `quadrants` zetten dingen naast elkaar.
+
+  Thema-eigen (oculus): de constructie is het motief van dit thema, niet iets
+  wat elk deck nodig heeft.
+
+  Gebruik:
+    ---
+    layout: vanishing-point
+    image: /cursus-esthetica/images/inleiding/school-of-athens.png
+    focus: [50, 46]        # procenten van het BEELDkader, niet van de slide
+    rays: 16               # optioneel, standaard 14
+    label: verdwijnpunt    # optioneel, standaard 'verdwijnpunt'
+    caption: Rafaël, De school van Athene, 1509–1511   # optioneel
+    ---
+
+  Klikken: 1 = de lijnen, 2 = de horizon, 3 = het punt met zijn label.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { resolveAsset } from '../../layouts-base/utils'
+
+const props = withDefaults(
+  defineProps<{
+    image: string
+    focus?: number[]
+    rays?: number
+    label?: string
+    caption?: string
+  }>(),
+  { focus: () => [50, 50], rays: 14, label: 'verdwijnpunt', caption: '' },
+)
+
+const src = computed(() => resolveAsset(props.image))
+const fx = computed(() => props.focus[0] ?? 50)
+const fy = computed(() => props.focus[1] ?? 50)
+
+/**
+ * Eindpunt van een straal vanuit (fx, fy) onder hoek `deg`, geknipt op de rand
+ * van het 100×100-viewBox. De kleinste positieve t is de eerste rand die de
+ * straal raakt; zonder die keuze schiet een lijn door de hoek naar buiten.
+ */
+function edgePoint(deg: number): { x: number; y: number } {
+  const rad = (deg * Math.PI) / 180
+  const dx = Math.cos(rad)
+  const dy = Math.sin(rad)
+  const ts: number[] = []
+  if (Math.abs(dx) > 1e-9) ts.push(((dx > 0 ? 100 : 0) - fx.value) / dx)
+  if (Math.abs(dy) > 1e-9) ts.push(((dy > 0 ? 100 : 0) - fy.value) / dy)
+  const t = Math.min(...ts.filter(v => v > 0))
+  return { x: fx.value + t * dx, y: fy.value + t * dy }
+}
+
+const lines = computed(() =>
+  Array.from({ length: props.rays }, (_, i) => edgePoint((i * 360) / props.rays)),
+)
+</script>
+
+<template>
+  <div class="slidev-layout vanishing-point">
+    <figure class="vp-frame">
+      <img :src="src" :alt="caption" />
+
+      <svg
+        class="vp-overlay"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <g v-click class="vp-rays">
+          <line
+            v-for="(p, i) in lines"
+            :key="i"
+            :x1="fx" :y1="fy" :x2="p.x" :y2="p.y"
+          />
+        </g>
+        <g v-click class="vp-horizon">
+          <line :x1="0" :y1="fy" :x2="100" :y2="fy" />
+        </g>
+      </svg>
+
+      <div v-click class="vp-point" :style="{ left: `${fx}%`, top: `${fy}%` }">
+        <span class="vp-point-label">{{ label }}</span>
+      </div>
+
+      <figcaption v-if="caption">{{ caption }}</figcaption>
+    </figure>
+  </div>
+</template>
+
+<style scoped>
+/* De figure krimpt tot de werkelijk gerenderde beeldmaat (shrink-to-fit op een
+   inline-block), zodat de overlay precies het beeld dekt en niet de slide. Dat
+   is de hele reden dat het beeld hier een <img> is en geen background-image. */
+.slidev-layout.vanishing-point {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+}
+
+.vp-frame {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+  max-width: 100%;
+  max-height: 100%;
+  margin: 0;
+}
+
+.vp-frame > img {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+}
+
+.vp-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+/* vector-effect houdt de lijn haarfijn ondanks de niet-uniforme viewBox-schaal */
+.vp-overlay line {
+  vector-effect: non-scaling-stroke;
+}
+
+.vp-rays line {
+  stroke: var(--color-accent);
+  stroke-width: 1;
+  opacity: 0.75;
+}
+
+.vp-horizon line {
+  stroke: var(--color-text);
+  stroke-width: 1;
+  stroke-dasharray: 6 5;
+  opacity: 0.65;
+}
+
+.vp-point {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 26px;
+  height: 26px;
+  pointer-events: none;
+}
+
+.vp-point::before,
+.vp-point::after {
+  content: '';
+  position: absolute;
+  background: var(--color-accent);
+}
+
+.vp-point::before {
+  left: 50%; top: 0; bottom: 0; width: 2px; transform: translateX(-50%);
+}
+
+.vp-point::after {
+  top: 50%; left: 0; right: 0; height: 2px; transform: translateY(-50%);
+}
+
+.vp-point-label {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  white-space: nowrap;
+  line-height: 1;
+  text-shadow: 0 1px 6px var(--color-bg);
+}
+
+.vp-frame > figcaption {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  line-height: 1.4;
+  background: linear-gradient(to top, rgba(19, 20, 23, 0.85), transparent);
+}
+</style>

--- a/slides/theme/oculus/package.json
+++ b/slides/theme/oculus/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "slidev-theme-oculus",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "keywords": ["slidev-theme", "slidev"],
+  "engines": { "slidev": ">=0.40.0" }
+}

--- a/slides/theme/oculus/styles/index.ts
+++ b/slides/theme/oculus/styles/index.ts
@@ -1,0 +1,2 @@
+import '@slidev/client/styles/layouts-base.css'
+import './layout.css'

--- a/slides/theme/oculus/styles/layout.css
+++ b/slides/theme/oculus/styles/layout.css
@@ -1,0 +1,397 @@
+/* ────────────────────────────────────────────────────────────────────
+   Oculus — Cursus Esthetica, hoofdstuk 02 "Wie mag in het midden staan?"
+
+   Een oculus is het gat in een koepel. Pozzo schilderde er een die er niet
+   was; Turrell zaagt er een die er wél is. Daartussen ligt het hoofdstuk.
+
+   Sfeer: donkere zaal, koele blauwe constructielijn, warme rode gloed.
+   Motief: een haarfijn perspectiefraster dat naar één punt loopt — en dat
+   per beweging van plaats verschuift, tot het in beweging 4 verdwijnt en
+   vervangen wordt door licht. Het thema voert dus zelf uit wat het
+   hoofdstuk beweert.
+
+   Familie met de hoofdstukpagina (Fraunces / Inter / JetBrains Mono,
+   #1a1a1a), maar met een eigen palet en een eigen geometrie.
+   ──────────────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..600&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  /* ── Palet — donkere zaal, blauwe constructie, warme gloed ─────── */
+  --color-bg:            #131417;   /* de zaal, iets koeler dan de site */
+  --color-bg-elevated:   #1c1e23;
+  --color-surface:       #242730;
+  --color-text:          #f2f0ea;
+  --color-text-muted:    #c3c1ba;
+  --color-text-dim:      #9a988f;
+  --color-text-quiet:    #7d7f88;
+  --color-border-subtle: #2e323c;
+  --color-rule:          #2e323c;   /* layouts-base leest dit */
+
+  --color-accent:        #3b85ca;   /* accentColor van het hoofdstuk */
+  --color-accent-soft:   rgba(59, 133, 202, 0.14);
+  --color-accent-line:   rgba(59, 133, 202, 0.30);  /* constructielijn */
+  --color-glow:          #6e2626;   /* eindpunt van skyspace-breathe */
+  --color-glow-soft:     rgba(110, 38, 38, 0.35);
+
+  /* ── Typografie ────────────────────────────────────────────────── */
+  --font-serif:   'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-sans:    'Inter', -apple-system, system-ui, sans-serif;
+  --font-mono:    'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace;
+
+  /* Modulaire schaal (1.2) */
+  --step--1: 0.833rem;
+  --step-0:  1rem;
+  --step-1:  1.2rem;
+  --step-2:  1.44rem;
+  --step-3:  1.728rem;
+  --step-4:  2.488rem;
+  --step-5:  3.583rem;
+  --step-6:  4.8rem;
+
+  /* Spacing */
+  --space-xs:  0.5rem;
+  --space-sm:  1rem;
+  --space-md:  1.5rem;
+  --space-lg:  2.5rem;
+  --space-xl:  4rem;
+  --space-2xl: 6rem;
+
+  --radius: 0;
+
+  /* Positie van het verdwijnpunt — per slide overschrijfbaar met
+     `class: vp-left` / `vp-right` / `vp-scattered` / `vp-none`. */
+  --vp-x: 62%;
+  --vp-y: 42%;
+
+  /* Slidev hooks */
+  --slidev-theme-primary: var(--color-accent);
+  --slidev-font-sans:  var(--font-sans);
+  --slidev-font-serif: var(--font-serif);
+  --slidev-font-mono:  var(--font-mono);
+}
+
+/* ── Basis ───────────────────────────────────────────────────────── */
+.slidev-layout {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-serif);
+  padding: var(--space-xl);
+  position: relative;
+  overflow: hidden;
+  font-feature-settings: "kern", "liga";
+}
+
+/* Het verdwijnpuntraster. Vier conische bundels haarlijnen die op
+   (--vp-x, --vp-y) samenkomen; naar de randen uitgefade zodat het een
+   constructie blijft en geen behang wordt. */
+.slidev-layout::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    repeating-conic-gradient(
+      from 0deg at var(--vp-x) var(--vp-y),
+      var(--color-accent-line) 0deg 0.10deg,
+      transparent 0.10deg 7.5deg
+    );
+  -webkit-mask-image: radial-gradient(
+    circle at var(--vp-x) var(--vp-y),
+    transparent 0, transparent 6%, black 34%, black 62%, transparent 96%);
+          mask-image: radial-gradient(
+    circle at var(--vp-x) var(--vp-y),
+    transparent 0, transparent 6%, black 34%, black 62%, transparent 96%);
+  opacity: 0.55;
+}
+
+/* De inhoud staat boven het raster. */
+.slidev-layout > * { position: relative; z-index: 1; }
+
+/* Verdwijnpunt verplaatsen — de bewegingen van het hoofdstuk.
+   1 centraal · 2 laag en excentrisch · 3 uiteen · 4 weg. */
+.slidev-layout.vp-center    { --vp-x: 50%; --vp-y: 50%; }
+.slidev-layout.vp-left      { --vp-x: 22%; --vp-y: 56%; }
+.slidev-layout.vp-right     { --vp-x: 82%; --vp-y: 38%; }
+.slidev-layout.vp-low       { --vp-x: 50%; --vp-y: 88%; }
+.slidev-layout.vp-none::before { display: none; }
+
+/* Beweging 3: geen enkel punt meer — het raster breekt in scherven. */
+.slidev-layout.vp-scattered::before {
+  background-image:
+    repeating-conic-gradient(from 12deg at 24% 30%,
+      var(--color-accent-line) 0deg 0.10deg, transparent 0.10deg 9deg),
+    repeating-conic-gradient(from 40deg at 71% 64%,
+      var(--color-accent-line) 0deg 0.10deg, transparent 0.10deg 9deg),
+    repeating-conic-gradient(from 75deg at 46% 88%,
+      var(--color-accent-line) 0deg 0.10deg, transparent 0.10deg 9deg);
+  -webkit-mask-image: linear-gradient(to bottom, black, black);
+          mask-image: linear-gradient(to bottom, black, black);
+  opacity: 0.30;
+}
+
+/* Beweging 4: geen constructie, alleen licht dat van onderop opkomt. */
+.slidev-layout.glow::before {
+  background-image: radial-gradient(
+    ellipse 80% 55% at 50% 108%,
+    var(--color-glow-soft) 0%, transparent 70%);
+  -webkit-mask-image: none;
+          mask-image: none;
+  opacity: 1;
+}
+
+/* ── Koppen ──────────────────────────────────────────────────────── */
+.slidev-layout h1,
+.slidev-layout h2,
+.slidev-layout h3,
+.slidev-layout h4 {
+  font-family: var(--font-display);
+  color: var(--color-text);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+}
+.slidev-layout h1 { font-size: var(--step-6); margin-bottom: var(--space-md); }
+.slidev-layout h2 {
+  font-size: var(--step-4);
+  margin-bottom: var(--space-md);
+  font-variation-settings: 'opsz' 100;
+}
+.slidev-layout h3 {
+  font-size: var(--step-2);
+  font-weight: 500;
+  margin-bottom: var(--space-sm);
+  color: var(--color-text);
+}
+.slidev-layout h4 { font-size: var(--step-1); font-weight: 500; }
+
+/* ── Lopende tekst ───────────────────────────────────────────────── */
+.slidev-layout p,
+.slidev-layout li {
+  font-family: var(--font-serif);
+  font-size: var(--step-1);
+  line-height: 1.55;
+  color: var(--color-text-muted);
+}
+.slidev-layout li + li { margin-top: 0.3em; }
+
+.slidev-layout strong { color: var(--color-text); font-weight: 600; }
+.slidev-layout em     { font-style: italic; color: var(--color-accent); }
+
+.slidev-layout a {
+  color: var(--color-accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-accent-soft);
+}
+.slidev-layout a:hover { border-bottom-color: var(--color-accent); }
+
+/* ── Code / gegevensblokken ──────────────────────────────────────── */
+.slidev-layout code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--color-surface);
+  padding: 0.1em 0.4em;
+  color: var(--color-text);
+}
+.slidev-layout pre {
+  background: var(--color-bg-elevated);
+  border-left: 2px solid var(--color-accent);
+  padding: var(--space-md);
+  font-size: var(--step-0);
+  line-height: 1.55;
+  margin-top: var(--space-md);
+  color: var(--color-text);
+}
+.slidev-layout pre,
+.slidev-layout pre code,
+.slidev-layout pre .line,
+.slidev-layout pre span { color: var(--color-text) !important; }
+.slidev-layout pre code { display: block; text-indent: 0; padding-left: 0; }
+
+/* ── Citaat ──────────────────────────────────────────────────────── */
+.slidev-layout blockquote {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--step-3);
+  line-height: 1.4;
+  color: var(--color-text);
+  background: none;
+  border-left: 1px solid var(--color-accent);
+  padding: 0 0 0 var(--space-md);
+  margin: var(--space-lg) 0;
+}
+
+/* ── Lijsten — het opsommingsteken is een verdwijnpunt ───────────── */
+.slidev-layout ul { list-style: none; padding-left: 0; }
+.slidev-layout ul > li { position: relative; padding-left: 1.5em; }
+.slidev-layout ul > li::before {
+  content: '';
+  position: absolute;
+  left: 0.3em;
+  top: 0.72em;
+  width: 5px;
+  height: 5px;
+  border: 1px solid var(--color-accent);
+  transform: rotate(45deg);
+}
+.slidev-layout ol { padding-left: 1.8em; }
+.slidev-layout ol > li::marker {
+  color: var(--color-accent);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+}
+
+/* ── COVER ───────────────────────────────────────────────────────── */
+.slidev-layout.cover {
+  display: flex; flex-direction: column; justify-content: center;
+  padding: var(--space-xl) var(--space-2xl);
+  --vp-x: 50%;
+  --vp-y: 50%;
+}
+.slidev-layout.cover::before { opacity: 0.85; }
+.slidev-layout.cover h1 {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 8.2vw, 7.5rem);
+  font-weight: 300;
+  font-variation-settings: 'opsz' 144;
+  line-height: 1.0;
+  letter-spacing: -0.035em;
+  margin-bottom: var(--space-md);
+  max-width: 16em;
+}
+.slidev-layout.cover h1 + p {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--step-2);
+  color: var(--color-text-muted);
+  max-width: 34em;
+}
+
+/* ── SECTIE — het verdwijnpunt van deze beweging ─────────────────── */
+.slidev-layout.section {
+  display: flex; flex-direction: column; justify-content: center;
+  padding-left: var(--space-2xl);
+}
+.slidev-layout.section h1 {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 8vw, 7rem);
+  font-weight: 300;
+  font-variation-settings: 'opsz' 144;
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  max-width: 14em;
+}
+.slidev-layout.section p {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-text-quiet);
+  margin-top: var(--space-md);
+}
+
+/* ── EINDE ───────────────────────────────────────────────────────── */
+.slidev-layout.end {
+  display: flex; flex-direction: column; justify-content: center;
+  padding-left: var(--space-2xl);
+}
+.slidev-layout.end h1 {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: var(--step-5);
+  color: var(--color-text);
+}
+.slidev-layout.end p {
+  color: var(--color-text-muted);
+  font-style: italic;
+  font-size: var(--step-3);
+}
+
+/* ── Beeldlayouts — padding weg, raster weg ──────────────────────── */
+.slidev-layout.image,
+.slidev-layout[class*="image-"] { padding: 0; }
+.slidev-layout.image::before,
+.slidev-layout[class*="image-"]::before { display: none; }
+
+.slidev-layout.image-right,
+.slidev-layout.image-left { padding: var(--space-xl); }
+.slidev-layout.image-right .my-cool-content-on-the-left,
+.slidev-layout.image-left  .my-cool-content-on-the-right { padding-right: var(--space-lg); }
+
+/* ── Meta-regels — jaartallen, plaatsnamen, rubrieken ────────────── */
+.slidev-layout .meta {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+.slidev-layout .meta-quiet {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-text-quiet);
+}
+
+/* ── Verdwijnpuntmarkering ───────────────────────────────────────
+   Een klein kruis precies op (--vp-x, --vp-y), dus altijd op het punt
+   waar de haarlijnen samenkomen — het kan niet uit elkaar lopen met het
+   raster. Optioneel label via het `data-label`-attribuut. */
+.slidev-layout .vp-marker {
+  position: absolute;
+  left: var(--vp-x);
+  top: var(--vp-y);
+  transform: translate(-50%, -50%);
+  width: 34px;
+  height: 34px;
+  z-index: 2;
+  pointer-events: none;
+}
+.slidev-layout .vp-marker::before,
+.slidev-layout .vp-marker::after {
+  content: '';
+  position: absolute;
+  background: var(--color-accent);
+}
+.slidev-layout .vp-marker::before {
+  left: 50%; top: 0; bottom: 0; width: 1px; transform: translateX(-50%);
+}
+.slidev-layout .vp-marker::after {
+  top: 50%; left: 0; right: 0; height: 1px; transform: translateY(-50%);
+}
+.slidev-layout .vp-marker[data-label]::marker { content: none; }
+.slidev-layout .vp-label {
+  position: absolute;
+  left: var(--vp-x);
+  top: calc(var(--vp-y) + 30px);
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  white-space: nowrap;
+}
+
+/* ── Gecentreerde layout (Slidev ingebouwd) ──────────────────────── */
+.slidev-layout.center { text-align: center; }
+.slidev-layout.center ul > li { display: inline-block; padding-left: 1.5em; }
+
+/* ── Haken voor layouts-base ─────────────────────────────────────── */
+.slidev-layout.compare::before,
+.slidev-layout.quadrants::before { opacity: 0.25; }
+.slidev-layout.quadrants .quadrant { background: var(--color-bg-elevated); }
+.slidev-layout.quadrants .quadrant h3 {
+  font-family: var(--font-display);
+  font-size: var(--step-2);
+  color: var(--color-accent);
+}
+.slidev-layout.paired-reveal::before { opacity: 0.25; }
+.slidev-layout.paired-reveal .paired-reveal-image img {
+  background: var(--color-bg-elevated);
+}

--- a/src/content/themes/perspectief-en-ruimte.mdx
+++ b/src/content/themes/perspectief-en-ruimte.mdx
@@ -104,6 +104,12 @@ videos:
     source: Tahed 
     start: 0
     end: 40   
+  fleabag:
+    youtube: i3tnMesJSGk
+    title: "Fleabag's Most Iconic Wall Breaks"
+    source: BBC
+    start: 0
+    end: 50
   abramovic:
     youtube: xlf68X2qEpM
     title: Marina & Ulay @ MoMA (The Artist is Present)
@@ -236,7 +242,7 @@ Tot hier was perspectief iets wat in het kunstwerk gebeurde. Zelfs toen het cent
 
 James Turrell gaat nog verder. Zijn [Skyspaces](fig:turrell) zijn kamers met een rechthoekig gat in het plafond. Meer niet. Je gaat liggen, of zitten, en kijkt omhoog. Langzaam verschuift de kleur van het licht in de kamer, en daardoor verschuift je perceptie van het gat. Soms lijkt de lucht vlak — een geschilderde rechthoek. Soms oneindig diep. Soms een kleur die de lucht niet kan zijn. Je verliest elk gevoel voor wat materieel is en wat niet. Het kunstwerk is niet het gat, niet de kamer, niet het licht. Het kunstwerk is *wat er in jouw hoofd gebeurt*.
 
-Dit is waar de vierde wand valt. In theater bedoelt men daarmee de onzichtbare muur tussen acteurs en publiek — de afspraak dat jij kijkt en zij spelen alsof je er niet bent. Brecht brak die wand opzettelijk door zijn acteurs jou te laten aanspreken. *Fleabag* doet het op televisie, [Deadpool](video:deadpool) op film. Maar Marina Abramović gaat het verst. In [The Artist is Present](video:abramovic) (2010) zit ze 736 uur lang stil in het MoMA. Bezoekers mogen één voor één tegenover haar gaan zitten en haar aankijken, zo lang ze willen. Geen performance, geen script, geen afstand. Mensen huilen. Zijzelf huilt. Er is geen kunstwerk behalve de blik tussen twee mensen in een kamer. De video toont je een erg kwetsbaar moment waarop haar voormalige levenspartner Ulay voor haar komt zitten.
+Dit is waar de vierde wand valt. In theater bedoelt men daarmee de onzichtbare muur tussen acteurs en publiek — de afspraak dat jij kijkt en zij spelen alsof je er niet bent. Brecht brak die wand opzettelijk door zijn acteurs jou te laten aanspreken. [*Fleabag*](video:fleabag) doet het op televisie, [Deadpool](video:deadpool) op film. Maar Marina Abramović gaat het verst. In [The Artist is Present](video:abramovic) (2010) zit ze 736 uur lang stil in het MoMA. Bezoekers mogen één voor één tegenover haar gaan zitten en haar aankijken, zo lang ze willen. Geen performance, geen script, geen afstand. Mensen huilen. Zijzelf huilt. Er is geen kunstwerk behalve de blik tussen twee mensen in een kamer. De video toont je een erg kwetsbaar moment waarop haar voormalige levenspartner Ulay voor haar komt zitten.
 
 Als je deze hele beweging in één vraag samenvat — van middeleeuws icoon tot Abramović — dan is het: *wie mag de ruimte bewonen?* Eerst alleen God. Dan de renaissance-kijker met zijn ene oog. Dan de kubist met zijn veelheid aan standpunten. Dan niemand: de abstracte schilder die zegt dat de ruimte een leugen is. En ten slotte: jij. Niet als toeschouwer, maar als mede-aanwezige. De vraag die bij een icoon begon — wie krijgt het centrum — wordt eindelijk omgedraaid. Het centrum is nu waar jij staat.
 


### PR DESCRIPTION
## Wat verandert er

Het eerste deck dat volledig volgens de herschreven slidev-skill (#34) is
gebouwd. 30 slides, vier bewegingen precies op de `##`-koppen van het hoofdstuk.

**Nieuw thema `oculus`.** Een oculus is het gat in een koepel: Pozzo schildert er
een die er niet is, Turrell zaagt er een die er wél is, en daartussen ligt het
hoofdstuk. Het motief is een verdwijnpuntraster dat per beweging verschuift —
centraal bij de renaissance, laag bij de barokke plafonds, in scherven bij het
kubisme, weg en vervangen door licht in beweging 4. Het thema voert uit wat het
hoofdstuk beweert.

**Twee nieuwe layouts.**

- `triptych` → `layouts-base`, dus gedeeld. Drie beelden op één rij, optioneel
  bijschriften en één per klik. Dit hoofdstuk heeft zes groepen van precies drie;
  `compare` doet er twee en `paired-reveal` toont er één tegelijk. Het splitsen
  van zo'n groep over twee slides is exact het mechanisme waardoor de dekking in
  de bestaande decks lekte (rosetta 1/3, art farm 1/3).
- `vanishing-point` → thema-eigen. Een beeld met constructielijnen die op klik
  samenkomen op een instelbaar punt. Het hoofdstuk vraagt daar letterlijk om
  ("trek de lijnen door: ze komen samen op één punt") en geen bestaande layout kan
  iets over een beeld heen leggen.
- `breathe` → thema-eigen. Full-bleed beeld met uitgesteld bijschrift en een
  trage gloed, dezelfde curve als `skyspace-breathe` op de hoofdstukpagina. Voor
  Turrell, waar een stilstaand rechthoekje op een beamer het slechtst denkbare
  medium is.

**Fleabag.** Het hoofdstuk noemde het bij naam zonder video-key. Toegevoegd aan
`videos:` en in de body gelinkt, zodat de vierde-wand-passage nu drie fragmenten
heeft (Fleabag, Deadpool, Abramović) in plaats van twee.

Closes #35

## Controle

- `npx astro check` → **0 errors, 0 warnings, 0 hints**, exit 0
- `npm run build` → exit 0, 5 decks
- `npm run check:slides -- perspectief-en-ruimte` → **beelden 22/22, video's 3/3,
  volledig**, exit 0. Elke groep van drie landt heel.
- Referentiecheck op het gewijzigde MDX: 10 figuurgroepen (22 beelden), 3 video's,
  0 problemen — elke `fig:`/`video:`-ref heeft een key, elke key wordt gebruikt,
  alle 22 `src:` bestaan onder `public/`.
- Fleabag-id apart geverifieerd via YouTube oEmbed: bestaat, titel
  *Fleabag's Most Iconic Wall Breaks*, kanaal BBC — dus geen dode embed.
- Slotslide opgezocht in de collectie, niet onthouden: module
  `kijken-en-luisteren`, dit hoofdstuk `order: 2`, eerstvolgende is
  `licht-en-schaduw` — *Wanneer wordt licht zelf het werk?*

### Render-check: gedeeltelijk

Er was geen scherm beschikbaar. Wat wél hard is aangetoond, uit de gebouwde
bundel: **nul** `resolveComponent(...)` in `dist/`, en elke nieuwe layout heeft
een eigen chunk met zijn scoped klassen erin (`.triptych-panel`, `.vp-rays`,
`.breathe-stage` + keyframes `oculus-breathe`). Een niet-gevonden layout laat
precies die chunks achterwege en geeft géén buildfout, dus dit onderscheidt hard
tussen "rendert" en "lege plek". Alle 22 beeldpaden zitten in de bundel en als
bestand in `dist/`; nul dubbele deck-base.

**Wat dat niet bewijst is of het er goed uitziet.** Twee dingen voor een mens met
een scherm:

1. De conic-gradient-haarlijnen van het rastermotief kunnen op een projector
   moiré geven.
2. De framing van `vanishing-point` op de Rafaël (`focus: [50, 45]`) is niet op
   de pixel geijkt.
3. Het Fleabag-fragment is geknipt op 0:00–0:50 zonder het te bekijken. De
   compilatie heet *Most Iconic Wall Breaks*, dus een wall break in de eerste
   vijftig seconden is vrijwel zeker — maar even nakijken kost tien seconden.

## Wat dit over de skill zegt

Dat was het eigenlijke doel van dit issue. §4 en §7 klopten woordelijk; het
`../` vs `./`-verschil is inderdaad de val waar je zonder die noot in trapt.
Twee gaten gevonden en in deze PR gedicht:

- **§4** noemde `--color-rule` optioneel. Dat is het in de code, maar bij een
  donker thema is de fallback een lichte rand rond elk quadrant. Bij een donker
  thema moet je hem zetten. (Bijt nu nergens — alle bestaande thema's zetten hem.)
- **§8** zei "open het deck en klik het door" zonder te zeggen wat je doet als je
  geen scherm hebt. Nu staat er dat je de check niet stil overslaat maar meldt wat
  je wel en niet kon vaststellen, met het bundelbewijs als ondergrens.

Eén observatie die geen wijziging werd omdat het een beslissing van de eigenaar
is: `licht-en-schaduw` hergebruikt `manifest`, dus "eigen thema per hoofdstuk"
is al één keer gebroken vóór dit issue. #37 gaat over dat deck; daar hoort de
keuze.
