### PR TITLE
routerMode: hash voor het inleiding-deck (#46)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -245,10 +245,22 @@ title: <titel van het hoofdstuk>
 info: |
   Cursus Esthetica — hoofdstuk NN
   <shortDescription>
+routerMode: hash
 ---
 ```
 
 Het verschil tussen `../` en `./` op die twee regels is geen typo.
+
+**`routerMode: hash` is verplicht, niet optioneel.** GitHub Pages heeft geen
+SPA-rewrite, dus in de standaard history-modus bestaat alleen de index van een
+deck: `/slides/<id>/2` en `/slides/<id>/presenter` geven allebei 404. Die tweede
+is de fatale — in dit project staat de hele les in de sprekersnotities (§1), en
+die zijn alleen via `/presenter` te zien. Een F5 midden in de les is dan ook het
+einde van de les.
+
+Geen enkele gate vangt dit: de build is groen mét en zonder, en lokaal in
+`npx slidev` werkt history-modus prima. Alleen de gedeployde site breekt. Het
+inleiding-deck heeft daar maanden zonder gestaan (#46).
 
 Elk deck heeft daarnaast `slides/<theme-id>/vite.config.ts`:
 

--- a/slides/inleiding/slides.md
+++ b/slides/inleiding/slides.md
@@ -3,6 +3,7 @@ theme: ../theme/manifest
 addons:
   - ./theme/layouts-base
 title: Maar is het kunst?
+routerMode: hash
 ---
 
 # Maar is het kunst<span style="color: var(--color-accent); font-style: italic; display: inline-block; transform: translateY(-0.08em) rotate(4deg);">?</span>


### PR DESCRIPTION
## Wat verandert er

`routerMode: hash` in de headmatter van het inleiding-deck — de enige van de vijf
die het niet had.

Gemeten op de live site, vóór deze fix:

```
200  /cursus-esthetica/slides/inleiding/
404  /cursus-esthetica/slides/inleiding/presenter
404  /cursus-esthetica/slides/inleiding/2
```

GitHub Pages heeft geen SPA-rewrite, dus in history-modus bestaat alleen de
index. De presentermodus is de fatale: in dit project staat de hele les in de
sprekersnotities, en die zijn alleen daar te zien. Een F5 midden in de les was
ook het einde van de les.

Closes #46

## Eén nuance die het issue niet had

Bij het meten bleek `/slides/meerstemmigheid/presenter` óók 404 te geven, en dat
deck heeft `routerMode: hash` wél. Dat is geen tegenspraak maar de werking van
hash-routing: het pad na het `#` bereikt de server nooit, dus het deck is te
bereiken op `/slides/<id>/#/presenter` en de server serveert altijd de index.

Wat de meting dus hard aantoont: **in history-modus zijn de sub-paden dood** —
er is geen URL waarop de presentermodus bestaat. Wat ze niet aantoont is dat de
presenterweergave in hash-modus ook echt rendert; een fragment is per definitie
niet met HTTP te testen. Dat is één blik in een browser na de deploy.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, 5 decks
- Diffvorm: 2 bestanden, working tree leeg.
- **Na de merge te doen**: `/cursus-esthetica/slides/inleiding/` opvragen en in de
  browser naar `#/presenter` gaan. Dat is de eigenlijke gate hier; de build is
  groen mét en zonder deze regel, en lokaal in `npx slidev` werkt history-modus
  gewoon. Alleen de gedeployde site breekt erop.

## Skill

§7 zegt nu dat `routerMode: hash` verplicht is in de headmatter, met de reden en
met de waarschuwing dat geen enkele gate dit vangt. Het stond in vier decks omdat
iemand het vier keer opnieuw ontdekte.
