### PR TITLE
image-layouts zetten hun naam als klasse; beeldregels beperkt tot full-bleed (#49)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -194,7 +194,7 @@ Waar hij hoort:
 - **Thema-eigen vorm → het thema zelf.** Iets wat alleen bij dít hoofdstuk hoort,
   in `slides/theme/<naam>/`.
 
-Twee dingen om niet mis te doen in een eigen layout:
+Drie dingen om niet mis te doen in een eigen layout:
 
 1. **Beeldpaden door `resolveAsset()`.** Elke layout die een `image`-prop
    verwerkt moet `resolveAsset` uit `../utils` gebruiken. Slidev prefixt anders
@@ -202,7 +202,23 @@ Twee dingen om niet mis te doen in een eigen layout:
    t.o.v. de site, en dan laadt het beeld niet. Dat is de reden dat `image.vue`,
    `image-left.vue`, `image-right.vue`, `compare.vue` en `paired-reveal.vue`
    Slidevs eigen layouts overschrijven.
-2. **Geen registratie nodig, wel bewijs dat het werkte.** Slidev laadt
+2. **De layout zet zijn eigen naam als klasse op zijn root.** Slidev doet dat
+   niet voor je. Elke layout in `layouts-base/` en elke thema-eigen layout doet
+   het nu — `<div class="slidev-layout triptych">`, `… image">`, `… breathe">` —
+   en een nieuwe layout hoort dat ook te doen. Vergeet je het, dan grijpt élke
+   themaregel op `.slidev-layout.<naam>` niets: geen buildfout, geen
+   waarschuwing, alleen een slide die er anders uitziet dan bedoeld. Dat is
+   precies wat er maandenlang misging bij `image`, `image-left` en
+   `image-right` (#49).
+
+   De niet-vanzelfsprekende helft: bij **`image-left` en `image-right` staat de
+   klasse op de teksthelft**, niet op de grid-wrapper eromheen. Die wrapper is
+   geen `.slidev-layout` en kan dus door geen enkele themaregel geraakt worden;
+   de beeldhelft evenmin, en die hoort ook geen thema-chroom te dragen. Richt
+   een themaregel voor die layouts dus op de teksthelft, en gebruik géén
+   `[class*="image-"]`-vangnet om `image` en `image-left/-right` in één regel te
+   pakken — dat treft de teksthelft mee.
+3. **Geen registratie nodig, wel bewijs dat het werkte.** Slidev laadt
    `layouts/` en `components/` van een addon automatisch. Een layout of component
    die níét gevonden wordt geeft **geen buildfout** — alleen een stille
    runtime-waarschuwing en een lege plek. Open het deck dus altijd echt.

--- a/slides/theme/aigles/styles/layout.css
+++ b/slides/theme/aigles/styles/layout.css
@@ -451,15 +451,14 @@
   max-width: 36em;
 }
 
-/* ── Image layouts ──────────────────────────────────────────── */
-.slidev-layout.image,
-.slidev-layout[class*="image-"] { padding: 0; }
+/* ── Image layouts — alleen full-bleed `image` ───────────────
+   Niet `[class*="image-"]`: bij image-left/-right draagt de teksthelft die
+   klasse, en die houdt zijn padding, de registratielijn en het kruisje.
+   Op een full-bleed werk gaan ze allebei weg — chroom hoort niet over een
+   kunstwerk, ook niet als het de handtekening van het thema is. */
+.slidev-layout.image { padding: 0; }
 .slidev-layout.image::before,
-.slidev-layout[class*="image-"]::before { display: none; }
-.slidev-layout.image-right,
-.slidev-layout.image-left { padding: calc(var(--space-xl) * 1.1) var(--space-xl) var(--space-xl); }
-.slidev-layout.image-right .my-cool-content-on-the-left,
-.slidev-layout.image-left  .my-cool-content-on-the-right { padding-right: var(--space-lg); }
+.slidev-layout.image::after { display: none; }
 
 /* ── Utility — meta, tampon, negation, cachet ──────────────── */
 .slidev-layout .meta,

--- a/slides/theme/contrapunctus/styles/layout.css
+++ b/slides/theme/contrapunctus/styles/layout.css
@@ -309,17 +309,11 @@
 }
 .slidev-layout.end p { color: var(--color-text-muted); font-style: italic; }
 
-/* ── Image layouts — kill default padding ──────────────────── */
-.slidev-layout.image,
-.slidev-layout[class*="image-"] { padding: 0; }
-.slidev-layout.image::before,
-.slidev-layout[class*="image-"]::before { display: none; }
-
-/* Image-right / image-left keep some breathing room on the text side */
-.slidev-layout.image-right,
-.slidev-layout.image-left { padding: var(--space-xl); }
-.slidev-layout.image-right .my-cool-content-on-the-left,
-.slidev-layout.image-left  .my-cool-content-on-the-right { padding-right: var(--space-lg); }
+/* ── Image layouts — alleen full-bleed `image` ──────────────
+   Niet `[class*="image-"]`: die klasse zit bij image-left/-right op de
+   teksthelft, en die houdt zijn padding en zijn notenbalk. */
+.slidev-layout.image { padding: 0; }
+.slidev-layout.image::before { display: none; }
 
 /* ── Mono caps utility — rubrics, dates, chapter labels ───── */
 .slidev-layout .meta,

--- a/slides/theme/layouts-base/layouts/image-left.vue
+++ b/slides/theme/layouts-base/layouts/image-left.vue
@@ -14,7 +14,7 @@ const style = computed(() => handleBackground(props.image, false, props.backgrou
 <template>
   <div class="grid grid-cols-2 w-full h-full auto-rows-fr">
     <div class="w-full h-full" :style="style" />
-    <div class="slidev-layout default" :class="props.class">
+    <div class="slidev-layout default image-left" :class="props.class">
       <slot />
     </div>
   </div>

--- a/slides/theme/layouts-base/layouts/image-right.vue
+++ b/slides/theme/layouts-base/layouts/image-right.vue
@@ -13,7 +13,7 @@ const style = computed(() => handleBackground(props.image, false, props.backgrou
 
 <template>
   <div class="grid grid-cols-2 w-full h-full auto-rows-fr">
-    <div class="slidev-layout default" :class="props.class">
+    <div class="slidev-layout default image-right" :class="props.class">
       <slot />
     </div>
     <div class="w-full h-full" :style="style" />

--- a/slides/theme/layouts-base/layouts/image.vue
+++ b/slides/theme/layouts-base/layouts/image.vue
@@ -11,7 +11,7 @@ const style = computed(() => handleBackground(props.image, false, props.backgrou
 </script>
 
 <template>
-  <div class="slidev-layout w-full h-full" :style="style">
+  <div class="slidev-layout image w-full h-full" :style="style">
     <slot />
   </div>
 </template>

--- a/slides/theme/manifest/styles/layout.css
+++ b/slides/theme/manifest/styles/layout.css
@@ -216,10 +216,11 @@
 .slidev-layout.end h1 { color: var(--color-bg); font-size: clamp(3rem, 8vw, 8rem); }
 .slidev-layout.end p { color: var(--color-text-dim); }
 
-.slidev-layout.image,
-.slidev-layout[class*="image-"] { padding: 0; }
-.slidev-layout.image::before,
-.slidev-layout[class*="image-"]::before { display: none; }
+/* ── Beeldlayouts — alleen full-bleed `image` ─────────────────────
+   Niet `[class*="image-"]`: bij image-left/-right draagt de teksthelft
+   die klasse, en die hoort zijn padding en zijn chroom te houden. */
+.slidev-layout.image { padding: 0; }
+.slidev-layout.image::before { display: none; }
 
 /* Mono caps utility */
 .slidev-layout .meta {

--- a/slides/theme/oculus/styles/layout.css
+++ b/slides/theme/oculus/styles/layout.css
@@ -319,16 +319,13 @@
   font-size: var(--step-3);
 }
 
-/* ── Beeldlayouts — padding weg, raster weg ──────────────────────── */
-.slidev-layout.image,
-.slidev-layout[class*="image-"] { padding: 0; }
-.slidev-layout.image::before,
-.slidev-layout[class*="image-"]::before { display: none; }
-
-.slidev-layout.image-right,
-.slidev-layout.image-left { padding: var(--space-xl); }
-.slidev-layout.image-right .my-cool-content-on-the-left,
-.slidev-layout.image-left  .my-cool-content-on-the-right { padding-right: var(--space-lg); }
+/* ── Beeldlayouts — padding weg, raster weg ────────────────────────
+   Alleen de full-bleed `image`. Niet `[class*="image-"]`: bij
+   image-left/-right zit die klasse op de teksthelft, en dáár hoort het
+   raster te blijven — anders doet een `class: vp-low` op zo'n slide niets
+   meer. De beeldhelft is geen .slidev-layout en draagt sowieso geen raster. */
+.slidev-layout.image { padding: 0; }
+.slidev-layout.image::before { display: none; }
 
 /* ── Meta-regels — jaartallen, plaatsnamen, rubrieken ────────────── */
 .slidev-layout .meta {


### PR DESCRIPTION
## Wat verandert er

`image.vue`, `image-left.vue` en `image-right.vue` zetten hun eigen naam nu als
klasse op hun root. Dat deden ze als enige layouts niet — het was een kale
`<div class="slidev-layout w-full h-full">` — waardoor elke themaregel op
`.slidev-layout.image` dode CSS was, zonder buildfout en zonder waarschuwing.

Daarna zijn de regels die daardoor tot leven komen beperkt tot
`.slidev-layout.image`. De `[class*="image-"]`-tak is overal weg, want die pakte
ook de teksthelft van `image-left`/`image-right` mee — en dat is precies wat je
niet wil.

| thema | voor | na |
|---|---|---|
| manifest | `.image, [class*="image-"] {padding:0}` + `::before` op beide | `.image {padding:0}` + `.image::before{display:none}` |
| oculus | idem + herstelregel + `.my-cool-content-*` | `.image {padding:0}` + `.image::before{display:none}` |
| contrapunctus | idem + herstelregel + `.my-cool-content-*` | idem |
| aigles | idem + herstelregel + `.my-cool-content-*` | `.image {padding:0}` + `.image::before, .image::after {display:none}` |
| penumbra | — | niet aangeraakt |

De geschrapte padding-herstelregels waren per thema exact gelijk aan de eigen
basispadding van dat thema; ze herstelden dus alleen wat de padding-nul zelf had
weggenomen. Met die tak weg zijn ze overbodig. `.my-cool-content-on-the-left/right`
kwam uit Slidevs default theme en stond in geen enkel deck.

Closes #49

## De fix zou zelf iets gebroken hebben

Dat is de reden dat hier een checkpoint zat. In `manifest` staat geen
padding-herstelregel, anders dan in de drie andere thema's. Zodra
`[class*="image-"]` ging grijpen, verloor **slide 9 van het inleiding-deck** (de
Vermeer, "Danto voelt cynisch hier") alle padding — kop en citaat tegen de rand.
Door de regels tot `.image` te beperken raakt geen enkele selector die slide meer.

Tweede geval: in `oculus` zette slide 9 (Mona Lisa, image-right) expliciet
`class: vp-low`. Met de brede selector ging het raster daar uit en betekende
`vp-low` niets meer. Nu houdt die slide zijn raster.

## Wat er zichtbaar verandert — 22 slides in 3 decks

Slidenummers uit `@slidev/parser`, 1-based, zoals in de presenter.

- **belgisch-experiment** (aigles) — 17 slides: **8, 9, 12, 13, 14, 27, 28, 29,
  31, 32, 33, 36, 37, 38, 40, 41, 48**. Registratielijn én registratiekruisje
  verdwijnen van de full-bleed werken. De andere 33 slides houden ze, inclusief
  de 7 image-right-slides 5, 6, 7, 10, 11, 34, 39.
- **perspectief-en-ruimte** (oculus) — 4 slides: **3** (Maestà), **10** (Pozzo),
  **13** (Riley), **16** (Demoiselles). Het verdwijnpuntraster verdwijnt daar.
  Dit is het gedrag dat het issue beschrijft.
- **meerstemmigheid** (contrapunctus) — 1 slide: **6** (Notre-Dame). De notenbalk
  verdwijnt. De 7 image-right-slides 3, 9, 13, 16, 17, 24, 29 houden hem.
- **inleiding** (manifest) — visueel niets. Slide 9 houdt zijn padding.
- **licht-en-schaduw** (penumbra) — niets. Dezelfde CSS-contenthash voor en na.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, 5 decks
- `npm run check:slides` → identiek aan `main`, inclusief de bestaande gaten in
  drie decks. Dit issue raakt geen beelden.
- **CSS-audit over alle vijf de gebouwde deck-stylesheets**: geen enkel deck
  bevat nog een selector met `[class*=image-]`, `.image-left` of `.image-right`.
  De ongekwalificeerde basis-`::before` (raster, notenbalk, registratielijn) staat
  er in elk thema ongewijzigd naast, dus de andere slides zijn niet geraakt.
- Diffvorm: 8 bestanden, working tree leeg.

## Wat niet is vastgesteld

Er was geen browser beschikbaar. Alles hierboven komt uit de gebouwde CSS, de
gecompileerde Vue-chunks en de geparseerde slides. Dat sluit hard uit dat een
regel niet grijpt of dat een slide erbuiten valt, maar het is **geen oordeel over
hoe het eruitziet** — en dit is een PR die zichtbare vormgeving in drie live
decks verandert.

Vier decks om echt open te klikken: `belgisch-experiment` (grootste verandering
— worden die 17 werken niet te kaal zonder het drukkerschroom?),
`perspectief-en-ruimte` (slides 3 en 9 naast elkaar), `meerstemmigheid` (slide 6
tegen 9), en `inleiding` slide 9, die er precies uit moet zien als vandaag.

## Skill

§5 legt nu vast dat elke layout zijn eigen naam als klasse op zijn root zet, dat
Slidev dat niet voor je doet, en dat vergeten geen buildfout maar dode CSS
oplevert. Met de niet-vanzelfsprekende helft erbij: bij `image-left`/`image-right`
staat de klasse op de **teksthelft**, niet op de grid-wrapper — die is geen
`.slidev-layout` en dus onbereikbaar voor themaregels. En de waarschuwing om geen
`[class*="image-"]`-vangnet te gebruiken, want dat pakt precies die teksthelft mee.
