### PR TITLE
Accentkleur: afleiden in plaats van overschrijven (#44)

### DIFF
--- a/src/layouts/ThemeLayout.astro
+++ b/src/layouts/ThemeLayout.astro
@@ -256,6 +256,12 @@ const videos = (theme.data as any).videos ?? null;
 <style>
   /* ---- Grid ---- */
   .theme-grid {
+    /* De inline `style` hierboven zet `--color-accent` uit de frontmatter.
+       `--color-accent-soft` moet daar opnieuw uit afgeleid worden: een
+       `color-mix()` wordt berekend op het element waar ze gedeclareerd is,
+       dus de versie op `:root` in tokens.css blijft bij de globale accent
+       staan en zou hier de verkeerde kleur geven. */
+    --color-accent-soft: color-mix(in srgb, var(--color-accent) 8%, transparent);
     display: grid;
     grid-template-columns: 1fr;
     max-width: 1280px;

--- a/src/styles/themes/inleiding.css
+++ b/src/styles/themes/inleiding.css
@@ -1,9 +1,11 @@
 /* src/styles/themes/inleiding.css */
 
 :root {
-  /* Ducttape-geel vervangt fuchsia op deze pagina */
+  /* Ducttape-geel vervangt fuchsia op deze pagina. Moet gelijk blijven aan
+     `accentColor:` in de frontmatter — zie de noot in
+     perspectief-en-ruimte.css over waarom die kopie hier staat.
+     `--color-accent-soft` wordt afgeleid (tokens.css). */
   --color-accent:      #E8D547;
-  --color-accent-soft: rgba(232, 213, 71, 0.1);
 
   /* Iets warmere achtergrond — galeriemuur, niet zwart */
   --color-bg:          #1c1a17;

--- a/src/styles/themes/perspectief-en-ruimte.css
+++ b/src/styles/themes/perspectief-en-ruimte.css
@@ -1,8 +1,14 @@
 /* src/styles/themes/perspectief-en-ruimte.css */
 
 :root {
-  --color-accent:      #3B4CCA;
-  --color-accent-soft: rgba(59, 76, 202, 0.1);
+  /* Moet gelijk blijven aan `accentColor:` in de frontmatter van het
+     hoofdstuk. Die waarde zet ThemeLayout inline op `.theme-grid` en dekt
+     dus de cursustekst; deze kopie dekt wat daarbuiten valt — de
+     site-header gebruikt `--color-accent` ook. Ze zijn hier ooit uit
+     elkaar gelopen (#44): de frontmatter zei #3b85ca, dit bestand #3B4CCA,
+     en de pagina toonde allebei. `--color-accent-soft` staat er niet meer
+     bij; die wordt afgeleid (tokens.css). */
+  --color-accent:      #3b85ca;
   --color-bg:          #1a1a1a;
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -13,9 +13,14 @@
   --color-text-quiet:    #888888;
   --color-text-whisper:  #666666;
 
-  /* Accent */
+  /* Accent. `-soft` wordt afgeleid en nooit als losse waarde geschreven —
+     zo kan hij niet wegdrijven van de kleur waar hij op hoort te lijken.
+     Een hoofdstuk met `accentColor:` in de frontmatter overschrijft
+     `--color-accent` op `.theme-grid`; ThemeLayout leidt `-soft` daar
+     opnieuw af, want een afgeleide waarde wordt berekend waar ze
+     gedeclareerd staat, niet waar ze gebruikt wordt. */
   --color-accent:        #ED4B9E;
-  --color-accent-soft:   rgba(237, 75, 158, 0.08);
+  --color-accent-soft:   color-mix(in srgb, var(--color-accent) 8%, transparent);
 
   /* Typografie */
   --font-serif: 'Fraunces', Georgia, serif;


### PR DESCRIPTION
## Wat verandert er

`--color-accent-soft` is nergens meer een losse rgba-waarde. Hij wordt afgeleid:

```css
--color-accent-soft: color-mix(in srgb, var(--color-accent) 8%, transparent);
```

Dat is waar de drift vandaan kwam. De zachte variant moest met de hand op de
accentkleur lijken, en zodra iemand er één van beide veranderde liepen ze uiteen.

`perspectief-en-ruimte` had **drie** bronnen voor één kleur: `#3b85ca` in de
frontmatter, `#3B4CCA` in de eigen stylesheet, en de globale roze in
`tokens.css`. De pagina toonde er twee tegelijk — de frontmatterkleur inline op
`.theme-grid` voor de cursustekst, en de stylesheetkleur op `:root` voor alles
daarbuiten, waaronder de site-header. Twee blauwen op één pagina.

De frontmatterwaarde `#3b85ca` wint, zoals besloten.

Closes #44

## Waarom de afleiding twee keer staat

Eén keer in `tokens.css` op `:root`, en nog eens op `.theme-grid` in
`ThemeLayout`. Dat is geen dubbelop maar noodzaak: een `color-mix()` wordt
berekend op het element waar hij **gedeclareerd** staat, niet waar hij gebruikt
wordt. De versie op `:root` leest dus de globale accent, en zou binnen een
hoofdstuk met een eigen `accentColor` de verkeerde kleur geven. Op `.theme-grid`,
waar de frontmatterkleur inline staat, levert dezelfde formule wél de juiste.

## Wat er níét is opgelost

De twee hoofdstuk-stylesheets zetten `--color-accent` nog steeds op `:root`,
naast de frontmatter. Dat is nu gedocumenteerd met de reden erbij: die kopie dekt
wat buiten `.theme-grid` valt, en de site-header gebruikt `--color-accent` ook.
Weghalen zou de header op die twee pagina's terugzetten op de globale roze.

Dat is een ontwerpbeslissing, geen opruimwerk — vijf van de zeven hoofdstukken
met een `accentColor` hebben vandaag al een roze header en een gekleurde body.
Apart issue.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- Geen enkele losse `--color-accent-soft` meer in `src/styles/**`; de enige
  declaraties zijn de twee afgeleide.
- Diffvorm: 4 bestanden, working tree leeg.
- **Geen render-check** — geen browser beschikbaar. Wat verandert is subtiel en
  visueel: de header op `/perspectief-en-ruimte/` gaat van `#3B4CCA` naar
  `#3b85ca` (nu gelijk aan de cursustekst ernaast), en de zachte accent volgt
  overal de echte accent in plaats van een handmatige benadering. Dat hoort een
  mens even te zien, op `/inleiding/` en `/perspectief-en-ruimte/`.
