### PR TITLE
Slotslides naar het juiste hoofdstuk, en een check erop (#40)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -56,10 +56,15 @@ het hele hoofdstuk; hoe ver je in een lesuur komt, beslis je in de klas. De
 bewegingen zijn de natuurlijke pauzepunten.
 
 **De slotslide volgt uit de collectie, niet uit je geheugen.** `layout: end` met
-"Volgende keer" noemt het volgende hoofdstuk: dat is het thema met de eerstvolgende
-`order` binnen dezelfde module (`src/content/modules/<module>.md` heeft zelf een
-`order`, `src/content/themes/*.mdx` ook). Zoek het op vóór je het opschrijft — dit
-is drie keer op drie fout gegaan, één keer naar een hoofdstuk dat niet bestaat.
+"Volgende keer" noemt het volgende hoofdstuk in de cursusvolgorde: sorteer op de
+`order` van de module (`src/content/modules/<module>.md`) en dan op de `order` van
+het thema (`src/content/themes/*.mdx`), en neem het volgende — dat kan de eerste
+van de volgende module zijn. Is er geen volgende, dan belooft het deck er ook geen.
+
+Dit is drie keer op drie fout gegaan, één keer naar een hoofdstuk dat niet
+bestaat. `npm run check:slides` controleert het sinds #40 mee, dus je hoeft het
+niet met de hand na te lopen — maar schrijf het wel op uit de collectie en niet
+uit je hoofd.
 
 ## 3 — Alles wat het hoofdstuk toont, toont het deck ook
 

--- a/slides/check-coverage.mjs
+++ b/slides/check-coverage.mjs
@@ -95,6 +95,33 @@ function fileNameOf(path) {
   return path.slice(path.lastIndexOf('/') + 1);
 }
 
+// De cursusvolgorde: module-`order` eerst, dan thema-`order` binnen die module.
+// De slotslide van een deck ("Volgende keer") hoort de titel te noemen van het
+// thema dat hierop volgt. Dat is drie keer op drie fout gegaan omdat het met de
+// hand werd opgeschreven — één deck wees zelfs naar een hoofdstuk dat niet
+// bestaat. Vandaar deze controle.
+function buildCourseOrder() {
+  const modulesDir = join(projectRoot, 'src', 'content', 'modules');
+  const moduleOrder = {};
+  for (const file of readdirSync(modulesDir)) {
+    const fm = frontmatterOf(readFileSync(join(modulesDir, file), 'utf8'), file);
+    moduleOrder[file.replace(/\.md$/, '')] = fm.order;
+  }
+  return readdirSync(themesDir)
+    .map(file => {
+      const fm = frontmatterOf(readFileSync(join(themesDir, file), 'utf8'), file);
+      return { id: file.replace(/\.mdx$/, ''), module: moduleOrder[fm.module], order: fm.order, title: fm.title };
+    })
+    .sort((a, b) => a.module - b.module || a.order - b.order);
+}
+
+const courseOrder = buildCourseOrder();
+
+function nextThemeOf(themeId) {
+  const index = courseOrder.findIndex(theme => theme.id === themeId);
+  return index === -1 ? undefined : courseOrder[index + 1];
+}
+
 const requested = process.argv.slice(2).filter(arg => !arg.startsWith('-'));
 
 const decks = readdirSync(slidesDir, { withFileTypes: true })
@@ -146,7 +173,18 @@ for (const themeId of decks) {
   const videoKeys = Object.keys(chapter.videos ?? {});
   const missingVideos = videoKeys.filter(key => !deck.videos.has(`${themeId}/${key}`));
 
-  const complete = groups.length === 0 && missingVideos.length === 0;
+  // Slotslide: noemt hij het juiste volgende hoofdstuk?
+  const deckSource = readFileSync(join(slidesDir, themeId, 'slides.md'), 'utf8').replace(/\r\n/g, '\n');
+  const next = nextThemeOf(themeId);
+  const hasEndPromise = /^#\s*Volgende keer\s*$/m.test(deckSource);
+  let slotProbleem;
+  if (next && !deckSource.includes(next.title)) {
+    slotProbleem = `slotslide noemt "${next.title}" niet — dat is het volgende hoofdstuk (${next.id})`;
+  } else if (!next && hasEndPromise) {
+    slotProbleem = 'slotslide belooft een volgend hoofdstuk, maar dit is het laatste';
+  }
+
+  const complete = groups.length === 0 && missingVideos.length === 0 && !slotProbleem;
   if (!complete) incomplete++;
 
   const heading = [
@@ -163,6 +201,9 @@ for (const themeId of decks) {
   }
   if (missingVideos.length > 0) {
     console.log(`    ${'video ontbreekt'.padEnd(24)}       ${missingVideos.join(', ')}`);
+  }
+  if (slotProbleem) {
+    console.log(`    ${'volgende keer'.padEnd(24)}       ${slotProbleem}`);
   }
   for (const path of deck.wrongPrefix) {
     console.log(`    let op: beeldpad zonder '${siteBase}' — ${path}`);

--- a/slides/inleiding/slides.md
+++ b/slides/inleiding/slides.md
@@ -527,10 +527,15 @@ layout: end
 
 # Volgende keer
 
-*Wie heeft jouw smaak gemaakt?*
+*Wie mag in het midden staan?*
 
 <!--
-Bruggetje naar hoofdstuk 2: smaak als culturele constructie. Vraag voor thuis: kies
-één werk (foto, song, film, game) waarvan je zeker weet dat het mooi is. Probeer op
-te schrijven wáárom — en let op of je redenen *over jou* gaan, of *over het werk*.
+Bruggetje naar hoofdstuk 2. Vandaag stelden we drie vragen; volgende keer nemen we de
+derde — *waarom werkt het zo?* — en stellen hem aan één enkele keuze: waar de maker de
+kijker neerzet. Perspectief lijkt een techniek. Het is een beslissing over wie mag
+kijken en wie gezien wordt.
+
+Vraag voor thuis: zoek een beeld waarvan je kunt aanwijzen waar de maker stond — een
+nieuwsfoto, een filmstill, een screenshot uit een game. Wie staat er in het midden, en
+wie staat er net buiten beeld?
 -->

--- a/slides/meerstemmigheid/slides.md
+++ b/slides/meerstemmigheid/slides.md
@@ -774,12 +774,16 @@ layout: end
 
 # Volgende keer
 
-*Hoe wordt iets lelijk?*
+*Wie speelt er eigenlijk?*
 
 <!--
-Bruggetje naar het volgende hoofdstuk over het lelijke. Vraag voor thuis: zoek een
-muziekstuk waarvan je zeker weet dat het je raakt, en probeer aan te wijzen *waar* in
-het stuk dat gebeurt. Op welk moment? Welke stemmen?
+Bruggetje naar het volgende hoofdstuk. Vandaag luisterden we naar wát er tegelijk
+klinkt; volgende keer naar wie of wat het voortbrengt — instrumenten, machines,
+software, en de vraag wanneer de speler ophoudt de speler te zijn.
+
+Vraag voor thuis: zoek een muziekstuk waarvan je zeker weet dat het je raakt, en
+probeer aan te wijzen *waar* in het stuk dat gebeurt. Op welk moment, welke stemmen —
+en kun je horen wát dat geluid maakt?
 
 Tip: luister naar de Spotify-playlist van het hoofdstuk — Léonin tot Bulgaars vrouwenkoor.
 -->


### PR DESCRIPTION
## Wat verandert er

Twee slotslides wezen naar het verkeerde hoofdstuk. De derde uit het issue
(`licht-en-schaduw`, die "kleur en betekenis" zei) is vervallen: dat deck is in
#37 volledig herschreven en wijst al correct.

| deck | stond er | staat er nu |
|---|---|---|
| `inleiding` | *Wie heeft jouw smaak gemaakt?* | *Wie mag in het midden staan?* |
| `meerstemmigheid` | *Hoe wordt iets lelijk?* | *Wie speelt er eigenlijk?* |

De eerste is `smaak-klasse-macht` en zit in module 5, niet op plaats 2. De tweede
bestaat helemaal niet als hoofdstuk.

**De sprekersnotities zijn mee herschreven.** Dat was geen bijvangst: het
bruggetje beloofde inhoud die het volgende hoofdstuk niet heeft, en de vraag voor
thuis bereidde de verkeerde les voor. Inleiding stuurde de klas op pad met "kies
één werk waarvan je zeker weet dat het mooi is" — een smaakoefening voor een les
over perspectief. Die is nu: zoek een beeld waarvan je kunt aanwijzen waar de
maker stond, en wie er net buiten beeld staat.

Closes #40

## De check die dit voortaan vangt

`npm run check:slides` controleert de slotslide mee. Per deck bepaalt het de
cursusvolgorde (module-`order`, dan thema-`order`) en meldt het als de slotslide
de titel van het volgende hoofdstuk niet noemt — of als een deck een volgend
hoofdstuk belooft terwijl het het laatste is.

Dat de volgorde modulegrenzen oversteekt is hier geen theorie: `meerstemmigheid`
is de vierde van zeven in zijn module, maar een deck van de laatste van een
module moet naar de eerste van de volgende wijzen.

## Controle

**Bewijs dat de check werkt.** Een controle die niets vindt en een controle die
stuk is zien er identiek uit. Dus met de twee slides tijdelijk teruggedraaid
(`git stash`):

```
inleiding        volgende keer  slotslide noemt "Wie mag in het midden staan?" niet
                                — dat is het volgende hoofdstuk (perspectief-en-ruimte)
meerstemmigheid  volgende keer  slotslide noemt "Wie speelt er eigenlijk?" niet
                                — dat is het volgende hoofdstuk (instrumentontwikkeling)
```

Precies de twee die fout waren, en geen andere. Na de fix meldt hij er nul.
`belgisch-experiment` wordt terecht niet gemeld: dat is het laatste hoofdstuk van
de cursus en het deck belooft ook geen volgende — het eindigt op een open vraag.

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, 5 decks
- De dekkingscijfers zijn onveranderd; dit issue raakt geen beelden.
- Diffvorm: 4 bestanden, working tree leeg.
- Geen render-check: de wijziging zit in twee slotslides en in sprekersnotities.
  Wat de klas ziet is één regel cursieve titel, geverifieerd via de check.

## Skill

§2 zei dat het volgende hoofdstuk "de eerstvolgende `order` binnen dezelfde
module" is. Dat klopt niet aan een modulegrens en is nu gecorrigeerd, met de
verwijzing naar het commando erbij.
