### PR TITLE
Vooruitwijzingen zonder bestemming in licht-en-schaduw (#47)

### DIFF
--- a/src/content/themes/licht-en-schaduw.mdx
+++ b/src/content/themes/licht-en-schaduw.mdx
@@ -148,7 +148,7 @@ Dat is precies wat kardinaal Meisner stoorde, en zijn bezwaar verdient een eerli
 
 Voor Richter zelf zat daar het hele punt. Hij zei achteraf: *ik wilde dat het raam iets vanzelfsprekends had, iets alledaags. In geen geval kleurlawaai.* Geen lood om de vierkanten samen te houden — alleen siliconenkit op een drager. Geen hiërarchie, geen verdwijnpunt, geen verhaal. Alleen kleur, licht, en een toeschouwer die mag uitmaken wat ervan komt.
 
-Onthoud dat. Je telefoonscherm werkt precies zo: een backlight, een gekleurd filter, een beeld dat alleen bestaat zolang de stroom aan staat. Een glasraam is technisch een voorouder van een TFT-paneel. Wat dat betekent voor wat je elke dag in je hand houdt — daar komen we op terug.
+Je telefoonscherm werkt precies zo: een backlight, een gekleurd filter, een beeld dat alleen bestaat zolang de stroom aan staat. Een glasraam is technisch een voorouder van een TFT-paneel — en je hebt er elke dag een in je hand.
 
 ## Het licht als hoofdrolspeler
 
@@ -216,7 +216,7 @@ Vier antwoorden op één vraag. Suger en Richter laten licht érgens doorheen va
 
 Wat ze delen, alle vier: het werk *gebeurt*. Het *staat* niet. Sluit de Dom 's avonds en Richter is er niet meer. Schakel de stroom uit en Flavin is er niet meer. Vraag het koor om te zwijgen en Ligeti is er niet meer. Hang Belshazzar in een onverlichte kamer en zelfs Rembrandt verdwijnt — het kleed wordt zwart, het gezicht wordt zwart, de hele compositie zakt in tot een vlak van pigment.
 
-Een reproductie van licht-kunst is altijd een halve leugen, hoe scherp je telefoon ook fotografeert. De foto van Sainte-Chapelle die je net hebt bekeken? Een momentopname van één lichtstand op één april-middag in 2018. Volgende week zou het anders zijn. De Lux Aeterna die straks uit je speakers komt? Niet de uitvoering, niet de zaal, niet het lichaam dat de klank vasthoudt — een opname van een interpretatie van een partituur.
+Een reproductie van licht-kunst is altijd een halve leugen, hoe scherp je telefoon ook fotografeert. De foto van Sainte-Chapelle die je net hebt bekeken? Een momentopname van één lichtstand op één april-middag in 2018. Volgende week zou het anders zijn. De Lux Aeterna die je net hebt gehoord? Niet de uitvoering, niet de zaal, niet het lichaam dat de klank vasthoudt — een opname van een interpretatie van een partituur.
 
 Dit is geen verwijt. Reproducties zijn nuttig — anders had dit hoofdstuk geen enkele afbeelding kunnen tonen. Maar het zijn aanwijzingen, niet meer. De Dom van Keulen staat 350 kilometer verderop. Sainte-Chapelle staat in Parijs. Belshazzar hangt in Londen, Flavin grotendeels in Marfa, Texas. Lux Aeterna wordt komende winter ergens uitgevoerd, of niet. Het is allemaal toegankelijk — alleen niet vanaf je laptop.
 


### PR DESCRIPTION
## Wat verandert er

Twee zinnen in `licht-en-schaduw` die de lezer iets beloofden dat er niet is.

**De telefoonschermzin** (regel 151) beloofde een vervolg dat nergens komt:

> ~~Onthoud dat.~~ Je telefoonscherm werkt precies zo: een backlight, een gekleurd
> filter, een beeld dat alleen bestaat zolang de stroom aan staat. Een glasraam is
> technisch een voorouder van een TFT-paneel ~~— wat dat betekent voor wat je elke
> dag in je hand houdt, daar komen we op terug~~ **— en je hebt er elke dag een in
> je hand.**

Ook `Onthoud dat` aan het begin was een vooruitwijzing; die gaat mee. Wat er
stond blijft staan als vaststelling in plaats van als toezegging.

**De Lux Aeterna-zin** (regel 219) wees vooruit naar iets dat al geweest was:

> De Lux Aeterna die ~~straks uit je speakers komt~~ **je net hebt gehoord**?

Het fragment staat op regel 203, zestien regels eerder, en de parallelle bijzin
in dezelfde zin stond al in de verleden tijd ("De foto van Sainte-Chapelle die je
net hebt bekeken?"). Gevonden bij de sweep hieronder; meegenomen omdat het
hetzelfde bestand, dezelfde fout en een tijdcorrectie zonder nieuwe inhoud is.

Closes #47

## De sweep

23 hoofdstukken doorzocht op "daar komen we op terug", "later meer", "in een
volgend hoofdstuk", "verderop", "zoals we nog zullen zien", "onthoud dat" en
varianten, plus alle vermeldingen van het woord *hoofdstuk*.

**Negen vooruitwijzingen zijn in orde** en blijven staan — ze wijzen naar een
plek die echt bestaat, meestal een tiental regels verderop in hetzelfde hoofdstuk
(*Olympia* in beweging-en-dynamiek, de palingstijl en de sloop van het Maison du
Peuple in art nouveau, de hernomen vraag in smaak-klasse-macht) en soms naar een
ander hoofdstuk dat geschreven is (Hiroshige in licht-en-schaduw, Danto in de
inleiding).

**Geen enkele wijst naar een stub.** De twee kandidaten uit het issue,
`digitale-kunst` en `kleur-en-emotie`, worden nergens bij naam genoemd.

**Eén vondst is niet aangeraakt**, want ze vraagt nieuwe tekst en zit in een
ander hoofdstuk: `smaak-klasse-macht` regel 269 zegt *"de Guerrilla Girls, die we
in het vorige hoofdstuk zagen"* — en dat hoofdstuk bestaat niet. Guerrilla Girls
komen in geen enkel ander hoofdstuk voor. Apart issue.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- `npm run check:chapters -- licht-en-schaduw` → in orde, exit 0
- Diffvorm: 1 bestand, 2 regels, working tree leeg.
- Render: geen browser beschikbaar. In plaats daarvan de pagina over HTTP
  opgehaald uit `npm run dev` — status 200, en de nieuwe zin staat letterlijk in
  de HTML; "daar komen we op terug" en "Onthoud dat." komen er niet meer in voor.
  Er is geen markup gewijzigd, alleen platte tekst binnen bestaande alinea's.
