### PR TITLE
meerstemmigheid-deck aanvullen: 3 video's en 4 beelden (#38)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -90,6 +90,14 @@ precies daarvoor.
 Staan er drie beelden in de groep, dan is de vraag welke layout die drie draagt —
 niet welk beeld het beste is.
 
+**Maar "niet reduceren" betekent niet "altijd op één slide".** Een figuurgroep is
+soms een reeks — Richters raam van vier kanten, de drie Rosetta-stills — en dan
+hoort ze bij elkaar. Soms zijn het twee argumenten op twee momenten in dezelfde
+beweging. De Bach-groep in `meerstemmigheid` is dat laatste: een portret en een
+autograaf-folio, en die naast elkaar zetten breekt de kijk-dan-luisterbeweging
+die de les daar maakt. De regel is dat elk beeld een plek krijgt, niet dat de
+groep één slide krijgt.
+
 Bij meerstemmigheid ontbreken `chakrulo`, `erraji` en `perotin`: dat zijn geen
 illustraties maar de luistervoorbeelden zelf, in een hoofdstuk dat over horen
 gaat. Een ontbrekende video is daarom zwaarder dan een ontbrekend beeld — zonder

--- a/slides/meerstemmigheid/slides.md
+++ b/slides/meerstemmigheid/slides.md
@@ -62,6 +62,35 @@ het hoorden: "This is it." UNESCO erkende het in 2001 als immaterieel werelderfg
 -->
 
 ---
+
+## Chakrulo
+
+<div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
+
+<CourseVideoInline id="meerstemmigheid/chakrulo" style="width: 60%;" />
+
+<div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
+
+Onderaan een drone die de bodem vasthoudt.
+
+Daarboven de stem die het verhaal vertelt.
+
+En een falsetto die om de twee anderen heen draait.
+
+</div>
+
+</div>
+
+<!--
+Ensemble Rustavi, anderhalve minuut. Speel eerst, praat daarna. Vraag tijdens het luisteren
+om te tellen: hoeveel stemmen hoor je tegelijk? Laat ze het hardop zeggen vóór je "drie"
+bevestigt — wie alleen naar de bovenste lijn luistert, hoort er één.
+
+Pas hierna doorklikken. De claim op de volgende slide moet landen op een klas die het net
+gehoord heeft, niet op gezag van de docent.
+-->
+
+---
 layout: center
 class: text-center
 ---
@@ -134,6 +163,52 @@ ze heeft geheugen. Andere tradities behouden polyfonie mondeling — eindeloos v
 -->
 
 ---
+layout: compare
+left: /cursus-esthetica/images/meerstemmigheid/erraji-1.jpg
+right: /cursus-esthetica/images/meerstemmigheid/erraji-2.jpg
+---
+
+<!--
+Hassan Erraji — Marokkaans, zanger en oedspeler, al decennia werkzaam vanuit Engeland.
+Links live op het podium, rechts een albumhoes.
+
+Stel hem in twee zinnen voor en laat het daarbij. Het gaat zo dadelijk om wat je hoort,
+niet om zijn biografie — dit is de slide waarop de klas een gezicht krijgt bij een naam,
+meer niet.
+-->
+
+---
+
+## Stem en oed
+
+<div style="display: flex; gap: var(--space-lg); align-items: center; margin-top: var(--space-md);">
+
+<CourseVideoInline id="meerstemmigheid/erraji" style="width: 60%;" />
+
+<div style="flex: 1; font-family: var(--font-serif); font-size: var(--step-0); color: var(--color-text-muted);">
+
+Dezelfde melodie.
+
+Tegelijk, en net niet gelijk.
+
+Geen noot papier — van speler op speler.
+
+</div>
+
+</div>
+
+<!--
+Hassan Erraji, NIKRIZ, WOMAD 2011. Eén minuut. Vraag vooraf: is dit één stem of twee?
+Laat de klas kiezen en laat ze het niet eens worden — er is geen goed antwoord, en dat is
+precies het punt. Het woord is heterofonie: twee sporen die dezelfde weg lopen, het ene
+een haar later dan het andere.
+
+Sluit hardop aan op de vorige slide. De uitvinding van Léonin is het *opschrijven*; hier
+hoor je samen klinken zonder dat er ook maar iets is opgeschreven. Notatie is niet de
+voorwaarde voor meerstemmigheid — ze is de voorwaarde voor een traditie met geheugen.
+-->
+
+---
 
 ## Viderunt omnes
 
@@ -160,6 +235,45 @@ Antwoord: omdat de kathedraal zo werkt. Je zingt tegen je eigen galm.
 -->
 
 ---
+layout: quadrants
+---
+
+## Drie keer tegelijk
+
+::q1::
+
+### Erraji · Marokko
+*heterofonie* — 2 lijnen, 1 melodie
+
+::q2::
+
+### Chakrulo · Georgië
+*polyfonie* — 3 lijnen, 3 stemmen
+
+::q3::
+
+### Léonin · Parijs, ca. 1170
+*organum* — 2 lijnen, 2 stemmen
+
+::q4::
+
+### en dan
+Pérotin, rond 1200: **vier**
+
+<!--
+Alle drie zijn nu gehoord — Chakrulo in de openingsbeweging, Erraji en Léonin net.
+Geef hier de drie woorden.
+
+Let op de volgorde: Léonin staat bewust niet vooraan. Hij is de eerste van wie we de naam
+kennen, en dat is een feit over schrift, niet over wie het eerst samen zong.
+
+Vraag terug: welke van de drie kende de andere twee? Geen enkele. Drie tradities, drie
+oplossingen, onafhankelijk van elkaar.
+
+Zet dan de teller klaar — 1, 2, 3 — en klik door. De volgende stap is vier.
+-->
+
+---
 layout: image-right
 image: /cursus-esthetica/images/meerstemmigheid/magnus-liber-1.jpg
 ---
@@ -180,6 +294,42 @@ Léonins opvolger trekt de logica door.
 Pérotin pakt waar Léonin stopte. Vier stemmen. Voor wie gewend was aan één enkele
 melodielijn (gregoriaans) was dit overweldigend. Het Magnus Liber Organi werd het
 referentiewerk waar alle kathedraalscholen mee werkten.
+-->
+
+---
+
+## Viderunt omnes · twee keer
+
+<div style="display: flex; gap: var(--space-md); align-items: flex-start; margin-top: var(--space-md);">
+
+<div style="flex: 1;">
+
+<CourseVideoInline id="meerstemmigheid/leonin" />
+
+<p class="meta-quiet" style="margin-top: var(--space-xs);">Léonin · ca. 1170 · twee stemmen</p>
+
+</div>
+
+<div style="flex: 1;">
+
+<CourseVideoInline id="meerstemmigheid/perotin" />
+
+<p class="meta-quiet" style="margin-top: var(--space-xs);">Pérotin · ca. 1200 · vier stemmen</p>
+
+</div>
+
+</div>
+
+<!--
+Hetzelfde stuk, dertig jaar later. Links Early Music Consort of London, David Munrow;
+rechts The Hilliard Ensemble.
+
+Dertig seconden links, dan meteen dertig seconden rechts. Niet omgekeerd, en geen uitleg
+ertussen — de sprong is alleen hoorbaar als de twee tegen elkaar aan staan.
+
+Vraag daarna: wat is erbij gekomen? Niet "meer noten" — meer *lijnen*. Onderaan houdt de
+tenor in allebei precies dezelfde gregoriaanse melodie aan. Laat de klas zelf zeggen
+waarom dit voor tijdgenoten een schok was.
 -->
 
 ---
@@ -214,6 +364,24 @@ begin een technische, mathematische praktijk is.
 -->
 
 ---
+layout: image
+image: /cursus-esthetica/images/meerstemmigheid/pythagoras-1.png
+backgroundSize: contain
+---
+
+<!--
+Stille beeldslide — laat de klas eerst kijken. Vraag: wat gebeurt hier, en waarom staan er
+getallen bij die hamers? Houd het antwoord vast tot de volgende slide.
+
+Pythagoras en de smid, houtsnede uit Franchino Gaffurio's Theorica Musicae, 1492. Bijna
+tweeduizend jaar na Pythagoras zelf, en nog altijd hét plaatje waarmee de muziekwetenschap
+zichzelf uitlegt.
+
+Boëthius vertaalde dat verhaal rond 510 in De Institutione Musica. Standaardwerk voor zes
+eeuwen: aan elke kathedraalschool die polyfonie wilde onderwijzen lag een exemplaar.
+-->
+
+---
 layout: quadrants
 ---
 
@@ -243,7 +411,8 @@ wrijving — dissonant
 Pythagoras, zes eeuwen voor Christus: als de ene snaar precies de helft is van de andere,
 klinken ze samen alsof ze één toon zijn. Verhouding 2:1, het octaaf. Eenvoudige
 verhoudingen produceren mooie samenklanken; complexe verhoudingen produceren wrijving.
-Boëthius vertaalde dit rond 510 in De Institutione Musica. Standaardwerk voor zes eeuwen.
+Dit is het antwoord op de vraag van de vorige slide: de getallen op de hamers zijn
+gewichten, en hun verhoudingen zijn de intervallen.
 -->
 
 ---
@@ -588,6 +757,24 @@ Sopraan 1 zet het thema in. Sopraan 2 valt in op een andere toonhoogte. Tenor vo
 Bas zet een eigen lijn. Horizontaal, zoals het sinds de twaalfde eeuw is gegroeid.
 Maar daaronder klinkt iets nieuws: een akkoordenschema dat sturend is. Polyfonie en
 harmonie zijn niet meer twee benaderingen. Ze zijn één.
+-->
+
+---
+layout: image
+image: /cursus-esthetica/images/meerstemmigheid/bach-2.jpg
+backgroundSize: contain
+---
+
+<!--
+Bachs eigen handschrift — een folio uit de autograaf van de Mass in B Minor.
+
+Ga naar het scherm en wijs de systemen aan. Laat de klas de zelfstandige lijnen tellen op
+papier, vóór er iets klinkt: elke balk is één stem, en elke stem heeft zijn eigen
+melodische leven.
+
+Vraag er meteen bij: als je die lijnen verticaal doorsnijdt, op één moment — wat staat er
+dan boven elkaar? Dat is de vraag waar het fragment op de volgende slide het antwoord op
+is.
 -->
 
 ---


### PR DESCRIPTION
## Wat verandert er

Zeven slides erbij, 69 → 76. Niets verplaatst, de zeven bewegingen ongewijzigd.

```
check:slides -- meerstemmigheid
  voor:  beelden 12/16   video's 5/8    (exit 1)
  na:    beelden 16/16   video's 8/8    volledig (exit 0)
```

De drie video's waren het zwaarst. Dit hoofdstuk heet *Wat hoor je tegelijk?* —
dat zijn geen illustraties maar de luistervoorbeelden zelf.

**Ze zijn niet achteraan bijgeplakt maar ingevoegd waar ze het argument dragen:**

- **Chakrulo** komt in beweging 0, *vóór* de slide die zegt dat meerstemmig
  zingen niet door het Westen is uitgevonden. Die claim moet landen op een klas
  die het net gehoord heeft, niet op gezag. De hele openingsbeweging bestaat om
  dat stuk — het deck toonde er tot nu toe alleen een foto en een tabelregel bij.
- **Erraji** komt in beweging 1, direct na de slide die zegt dat de eigenlijke
  uitvinding het *opschrijven* is. Hij is het tegenvoorbeeld dat het hoofdstuk er
  zelf naast zet: stem en oed, dezelfde melodie, geen noot papier. Vraag aan de
  klas: is dit één stem of twee? Er is geen goed antwoord, en dat is het punt.
- **Pérotin** staat op één slide náást Léonin — hetzelfde *Viderunt omnes*, twee
  stemmen tegen vier. De sprong is alleen hoorbaar als ze tegen elkaar aan staan;
  twee slides terugklikken breekt de les. Léonin wordt daarvoor bewust herhaald.

Verder: de twee Erraji-beelden als `compare` vóór het fragment, een
`quadrants`-recap *Drie keer tegelijk*, `pythagoras-1.png` als stille beeldslide
vóór de verhoudingen ("waarom staan er getallen op die hamers?"), en `bach-2.jpg`
groot vóór het Gloria-fragment — een partituur moet op een beamer leesbaar zijn.

**De comparator uit #57 wordt overgenomen als conclusie, niet als vorm.** Geen
drie spelers naast elkaar: op de site staan die samen omdat de student ze zelf
afspeelt, maar in de les doen de drie fragmenten drie verschillende dingen in
drie verschillende bewegingen. Wel de `quadrants`-recap in dezelfde kaartvolgorde
(Erraji — Chakrulo — Léonin), zodat ook in de les Léonin niet als eerste
uitvinder leest.

Closes #38

## Eén bestaande notitie aangeraakt

De enige wijziging die bestaande inhoud verandert in plaats van aanvult. Uit de
notitie bij de `quadrants`-slide *Pythagoras · −500* is deze regel verplaatst
(niet gedupliceerd) naar de nieuwe Pythagoras-beeldslide ernaast:

> Boëthius vertaalde dit rond 510 in *De Institutione Musica*. Standaardwerk voor
> zes eeuwen.

Er kwam de terugkoppeling naar de vraag die de beeldslide stelt voor in de plaats:
de getallen op de hamers zijn gewichten, hun verhoudingen zijn de intervallen.
Gecontroleerd in de bundel: `De Institutione Musica` komt exact 1× voor in `dist/`.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- `npm run check:slides -- meerstemmigheid` → 16/16 en 8/8, volledig
- Slotslide-controle uit #40 groen: wijst naar `instrumentontwikkeling`,
  *Wie speelt er eigenlijk?*
- Diffvorm: het deck plus één alinea in de skill, working tree leeg.

### Render-check: gedeeltelijk

Geen scherm. Uit de gebouwde bundel: **nul** `resolveComponent(` — alle acht
layouts en beide videocomponenten zijn bij de build opgelost. Negen
`CourseVideoInline`-instanties in de bron, negen id-referenties in de chunk, en
alle acht keys staan in `videos.generated.json`, dus `Onbekend fragment` is
uitgesloten. De vier nieuwe beeldpaden zitten in de chunk en de bestanden staan
op disk.

Drie dingen die alleen een scherm beantwoordt: of de twee spelers op de
A/B-slide groot genoeg blijven op een beamer, of `pythagoras-1.png` met
`contain` de getallen op de hamers leesbaar houdt (daar hangt die slide op), en
of `bach-2.jpg` groot genoeg oogt om systemen te tellen.

## Twee dingen die dit issue opleverde

**Het flex-patroon voor twee spelers is te omslachtig** — het bewijs waar #61 om
vroeg. Bij één speler naast tekst geef je `style="width: 60%"` mee en klaar. Bij
twee moet elke speler in een eigen `flex: 1`-wrapper, de `style`-prop leeg (anders
krijg je 60% van 50%), en het bijschrift met de hand als `<p class="meta-quiet">`
eronder, want er is geen captionmechanisme. Drie niveaus geneste HTML in markdown
voor wat `compare` bij beelden in vier frontmatterregels doet, plus geen
label-per-kant. Dat is de vorm die de `duet`-layout moet krijgen.

**De skill was te stellig.** §3 zei dat een figuurgroep met meerdere beelden niet
tot één beeld gereduceerd wordt, en noemde `compare`/`triptych` als de oplossing —
alsof zo'n groep dus op één slide hoort. Voor de Bach-groep klopt dat niet:
`bach-1` (portret) en `bach-2` (autograaf) zijn geen reeks maar twee argumenten
op twee momenten, en ze naast elkaar zetten breekt de kijk-dan-luisterbeweging.
De regel is nu: elk beeld krijgt een plek, niet de groep één slide.

## Nog open

`npm run check:chapters -- meerstemmigheid` geeft nog één melding: `erraji:
figuurgroep wordt nergens in de body gebruikt`. Dat is nu een **bewuste
toestand** — de beelden blijven in `figures:` en landen in het deck, niet in de
cursustekst. Wordt zo genoteerd in #53.
