### PR TITLE
inleiding: het beeld waarop de banaan wordt opgegeten (#65)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -74,10 +74,13 @@ werd opgeschreven, en zo staan ze er nu:
 
 | deck | toen | nu |
 |---|---|---|
-| inleiding | 9/10 beelden, 4/4 video | 9/10, 4/4 |
+| inleiding | 9/10 beelden, 4/4 video | **10/10, 4/4** (#65) |
 | meerstemmigheid | 12/16, 5/8 | **16/16, 8/8** (#38) |
 | belgisch-experiment | 21/29, 2/2 | **29/29, 2/2** (#39) |
 | licht-en-schaduw | 0/20, 0/4 | **20/20, 4/4** (#37) |
+
+`npm run check:slides` staat sindsdien op exit 0 over alle vijf de decks. Dat is
+de toestand die je achterlaat, niet een die je mag verslechteren.
 
 En het lekt niet willekeurig. Het zijn de **figuurgroepen met meerdere beelden**
 die tot één worden teruggebracht: Rosetta 1 van 3, Art Farm 1 van 3, de

--- a/slides/inleiding/slides.md
+++ b/slides/inleiding/slides.md
@@ -42,6 +42,24 @@ Houd de antwoorden vast — die reactie zélf is het materiaal van deze cursus.
 -->
 
 ---
+layout: image
+image: /cursus-esthetica/images/inleiding/cattelan-2.jpg
+backgroundSize: contain
+---
+
+<!--
+Vier dagen later. Kunstenaar David Datuna haalt de banaan van de muur en eet hem
+op, midden op de beurs. Hij noemt het zelf een performance: *Hungry Artist*.
+
+Laat dit even staan zonder commentaar. Stel dan één vraag: is het werk nu stuk?
+
+Bijna iedereen zegt eerst ja. De galerie deed iets anders — ze plakte een nieuwe
+banaan op de muur en ging door. Datuna is nooit vervolgd; er viel niets te
+vervolgen. Klik dan pas door: op de volgende slide staat wat er dié dag in het
+dossier kwam te staan.
+-->
+
+---
 
 ## $120,000 · 0.14kg · edible · replaceable
 


### PR DESCRIPTION
## Wat verandert er

Eén slide in het inleiding-deck: `cattelan-2.jpg`, de foto waarop David Datuna de
banaan van de muur haalt en opeet.

Hij staat tussen de slide die het werk toont zoals het hing en de specsheet-slide
die erop volgt. Dat is de volgorde van het hoofdstuk zelf — *het hing er, iemand
at het op, de galerie hing een nieuwe op, het kunstwerk bleef bestaan* — en het
laat twee regels op de specsheet eindelijk landen:

```
status        opgegeten op 7 december 2019
              vervangen op 7 december 2019
```

Die stonden er al, zonder dat de klas het opeten ooit had gezien.

**Eigen slide, geen `compare`.** Het hoofdstuk zet het als opeenvolging neer, niet
als vergelijking; twee beelden naast elkaar zou van een gebeurtenis een tweeluik
maken. De sprekersnotitie stuurt op de vraag die het beeld stelt — *is het werk nu
stuk?* — en zegt erbij dat bijna iedereen eerst ja zegt, en dat de galerie iets
anders deed.

Closes #65

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- `npm run check:slides` → **exit 0**, en dat is nieuw:

```
belgisch-experiment     beelden 29/29  video's 2/2    volledig
inleiding               beelden 10/10  video's 4/4    volledig
licht-en-schaduw        beelden 20/20  video's 4/4    volledig
meerstemmigheid         beelden 16/16  video's 8/8    volledig
perspectief-en-ruimte   beelden 22/22  video's 3/3    volledig
Alle 5 deck(s) tonen elk beeld en elke video uit hun hoofdstuk.
```

Toen de check in #36 werd gebouwd, miste geen enkel deck minder dan één beeld en
misten er samen 27 beelden en 7 video's.

- Diffvorm: het deck plus de dekkingstabel in de skill, working tree leeg.
- Geen render-check: geen scherm. Het beeld staat al onder `public/` en werd al
  door de site gebruikt, dus er is niets gedownload of hernoemd. Wat een scherm
  moet bevestigen is of `contain` de foto goed uitsnijdt in dit thema — sinds #49
  verdwijnt het themachroom op full-bleed beeldslides, en dit is de eerste nieuwe
  beeldslide in `manifest` sindsdien.

## Skill

De dekkingstabel in §3 staat nu compleet, met de aantekening dat exit 0 de
toestand is die je achterlaat en niet een die je mag verslechteren.
