### PR TITLE
23 bijschriften die niet bij hun beeld hoorden (#63)

### DIFF
--- a/public/images/belgisch-experiment/sources.json
+++ b/public/images/belgisch-experiment/sources.json
@@ -10,7 +10,7 @@
       "downloaded": "2026-05-20T14:32:17Z"
     },
     "broodthaers-aigles-2.jpg": {
-      "description": "Broodthaers, Musée d'Art Moderne — Département des Aigles, 1968-1972 — detailaanzicht",
+      "description": "Département des Aigles — een adelaar met de plaatjes uit de reeks, gereproduceerd op een boekomslag",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.moma.org/collection/works/146967",
@@ -65,7 +65,7 @@
       "downloaded": "2026-05-20T14:31:59Z"
     },
     "corillon-eanswythe-2.jpg": {
-      "description": "Corillon, On the Track of St Eanswythe's Waterway, 2021 — detail van de reliekschrijn-installaties",
+      "description": "Corillon, On the Track of St Eanswythe's Waterway, 2021 — een van de kastjes langs de route",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.creativefolkestone.org.uk/artists/patrick-corillon-artworks/",
@@ -97,7 +97,7 @@
       "downloaded": "2026-05-20T14:31:32Z"
     },
     "dardenne-rosetta-3.jpg": {
-      "description": "Dardenne, Rosetta, 1999 — Émilie Dequenne in de caravansite, foto Christine Plenus",
+      "description": "Dardenne, Rosetta, 1999 — Rosetta en Riquet aan tafel, foto Christine Plenus",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://lesfilmsdufleuve.be/en/movies/rosetta/",
@@ -153,7 +153,7 @@
       "downloaded": "2026-09-01T22:48:46Z"
     },
     "logos-robot-1.jpg": {
-      "description": "Logos M&M Robot Orchestra, Stichting Logos, Gent — Godfried-Willem Raes met de robots",
+      "description": "Logos M&M Robot Orchestra, Stichting Logos, Gent — het volledige orkest opgesteld in de Tetraëder",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.logosfoundation.org/",
@@ -161,7 +161,7 @@
       "downloaded": "2026-05-20T14:33:23Z"
     },
     "logos-robot-2.jpg": {
-      "description": "Logos M&M Robot Orchestra — concert in de Logos Tetraëder",
+      "description": "Logos M&M Robot Orchestra — een rij robots op wielen, elk een zelfontworpen instrument",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.logosfoundation.org/",
@@ -169,7 +169,7 @@
       "downloaded": "2026-05-20T14:33:27Z"
     },
     "logos-robot-3.jpg": {
-      "description": "Logos M&M Robot Orchestra — overzicht van het robotensemble",
+      "description": "Godfried-Willem Raes bij een van zijn robots — Stichting Logos, Gent",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.logosfoundation.org/",
@@ -185,7 +185,7 @@
       "downloaded": "2026-05-20T14:31:24Z"
     },
     "op-de-beeck-location-1.jpg": {
-      "description": "Hans Op de Beeck, Location (5), 2004 — interieur van het wegrestaurant",
+      "description": "Hans Op de Beeck, Location (5), 2004 — werktekening van de installatie",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://hansopdebeeck.com/works/2004/location-5",

--- a/public/images/beweging-en-dynamiek/sources.json
+++ b/public/images/beweging-en-dynamiek/sources.json
@@ -130,7 +130,7 @@
       "downloaded": "2026-06-10T17:26:39Z"
     },
     "tinguely-2.jpg": {
-      "description": "Jean Tinguely — Homage to New York, de machine (1960)",
+      "description": "Jean Tinguely — machinesculptuur van schroot, motoronderdelen en een krokodillenschedel",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.tinguely.ch",
@@ -138,7 +138,7 @@
       "downloaded": "2026-06-10T17:26:45Z"
     },
     "tinguely-3.jpg": {
-      "description": "Jean Tinguely — Homage to New York, de zelfvernietiging (1960)",
+      "description": "Jean Tinguely — assemblage met een antilopenschedel, een wiel en gebogen staal",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": null,
@@ -146,7 +146,7 @@
       "downloaded": "2026-06-10T17:26:50Z"
     },
     "tinguely-4.jpg": {
-      "description": "Jean Tinguely en Yves Klein — de machine als medekunstenaar",
+      "description": "Jean Tinguely — een grote machinesculptuur, tentoonstellingszicht",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://www.kunsthal.nl",

--- a/public/images/graffiti-en-street-art/sources.json
+++ b/public/images/graffiti-en-street-art/sources.json
@@ -66,7 +66,7 @@
       "downloaded": "2026-07-27T10:39:11Z"
     },
     "taki-2.jpg": {
-      "description": "TAKI 183 — tag, New York, begin jaren 1970",
+      "description": "Demetrius, de schrijver achter TAKI 183, zet zijn tag — jaren na dato",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://streetartnyc.org/blog/2015/06/29/the-legendary-taki-183-on-tagging-the-new-york-times-the-wall-on-207th-street-instafame-phantom-art-graffiti-and-more/",

--- a/public/images/licht-en-schaduw/sources.json
+++ b/public/images/licht-en-schaduw/sources.json
@@ -102,7 +102,7 @@
       "downloaded": "2026-05-10T10:18:18Z"
     },
     "richter-2.jpg": {
-      "description": "Gerhard Richter, Domfenster Köln, frontaal, 2007",
+      "description": "Gerhard Richter, Domfenster Köln, 2007 — het raam van buitenaf, in de gotische tracering",
       "source": "Wikimedia Commons",
       "license": "CC BY-SA",
       "page_url": "https://commons.wikimedia.org/wiki/Category:Richter_Window_in_the_Cologne_Cathedral",
@@ -115,7 +115,7 @@
       "downloaded": "2026-05-10T10:18:20Z"
     },
     "richter-4.png": {
-      "description": "Gerhard Richter, Domfenster Köln, frontaal, 2007, overzicht",
+      "description": "Gerhard Richter, Domfenster Köln, 2007 — het raam frontaal, 11.263 vierkanten in 72 kleuren",
       "page_url": "https://publicdelivery.org/gerhard-richter-cathedral/",
       "downloaded": "2026-05-10T10:18:20Z"
     },

--- a/public/images/meerstemmigheid/sources.json
+++ b/public/images/meerstemmigheid/sources.json
@@ -34,7 +34,7 @@
       "downloaded": "2026-05-11T16:34:44Z"
     },
     "erraji-1.jpg": {
-      "description": "Hassan Erraji, live in concert",
+      "description": "Hassan Erraji met zijn oed - studioportret",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": "https://bandonthewall.org/events/hassan-erraji/",
@@ -42,7 +42,7 @@
       "downloaded": "2026-05-11T16:53:49Z"
     },
     "erraji-2.jpg": {
-      "description": "Hassan Erraji — albumhoes",
+      "description": "Hassan Erraji, live in concert",
       "source": "directe URL",
       "license": "In Copyright",
       "page_url": null,
@@ -122,7 +122,7 @@
       "downloaded": "2026-05-11T16:34:39Z"
     },
     "pythagoras-1.png": {
-      "description": "Pythagoras en de smid, houtsnede uit Franchino Gaffurio's Theorica Musicae, 1492",
+      "description": "Pythagoras en de smeden — handschriftillustratie bij Boethius' De musica",
       "source": "Wikimedia Commons",
       "license": "Public domain",
       "page_url": "https://commons.wikimedia.org/wiki/File:Pythagoras.In.Der.Schmiede.De.musica.png",

--- a/slides/meerstemmigheid/slides.md
+++ b/slides/meerstemmigheid/slides.md
@@ -370,15 +370,18 @@ backgroundSize: contain
 ---
 
 <!--
-Stille beeldslide — laat de klas eerst kijken. Vraag: wat gebeurt hier, en waarom staan er
-getallen bij die hamers? Houd het antwoord vast tot de volgende slide.
+Stille beeldslide — laat de klas eerst kijken. Vraag: wat doet die man links, en waarom
+staat een filosoof toe te kijken in een smidse? Houd het antwoord vast tot de volgende
+slide.
 
-Pythagoras en de smid, houtsnede uit Franchino Gaffurio's Theorica Musicae, 1492. Bijna
-tweeduizend jaar na Pythagoras zelf, en nog altijd hét plaatje waarmee de muziekwetenschap
-zichzelf uitlegt.
+Handschriftillustratie bij Boëthius' De musica. Links staat PYTAGORAS, met zijn naam
+erboven geschreven; daarnaast slaan drie smeden op één aambeeld. Onderaan een schrijver en
+een harpspeler: het geluid wordt eerst gemeten, dan genoteerd, dan gespeeld. De hele
+redenering van dit hoofdstuk staat op één bladzijde.
 
-Boëthius vertaalde dat verhaal rond 510 in De Institutione Musica. Standaardwerk voor zes
-eeuwen: aan elke kathedraalschool die polyfonie wilde onderwijzen lag een exemplaar.
+Boëthius bracht het verhaal rond 510 samen in dat boek. Standaardwerk voor zes eeuwen: aan
+elke kathedraalschool die polyfonie wilde onderwijzen lag een exemplaar. Dit beeld ís dus
+niet een illustratie bíj de traditie — het is hoe die traditie zichzelf doorgaf.
 -->
 
 ---
@@ -411,8 +414,10 @@ wrijving — dissonant
 Pythagoras, zes eeuwen voor Christus: als de ene snaar precies de helft is van de andere,
 klinken ze samen alsof ze één toon zijn. Verhouding 2:1, het octaaf. Eenvoudige
 verhoudingen produceren mooie samenklanken; complexe verhoudingen produceren wrijving.
-Dit is het antwoord op de vraag van de vorige slide: de getallen op de hamers zijn
-gewichten, en hun verhoudingen zijn de intervallen.
+Dit is het antwoord op de vraag van de vorige slide: volgens het verhaal hoorde Pythagoras
+in een smidse dat sommige hamers samen mooi klonken en andere niet. Het verschil zat in hun
+gewicht, en de verhouding tussen die gewichten is de verhouding die je hier ziet. Of dat
+echt zo gebeurd is, weet niemand — het verhaal is ouder dan elke bron die het vertelt.
 -->
 
 ---

--- a/src/content/themes/architectuur-en-bouwprincipes.mdx
+++ b/src/content/themes/architectuur-en-bouwprincipes.mdx
@@ -56,7 +56,7 @@ figures:
           caption: Het klassieke zicht op de waterval
           source: https://commons.wikimedia.org/wiki/File:Classic_View_of_Fallingwater_National_Historic_Landmark.jpg
         - src: /images/architectuur/fallingwater-wijd.jpg
-          caption: Vanaf de beek gezien
+          caption: De terrassen van opzij, met bezoekers op het balkon
           source: https://commons.wikimedia.org/wiki/File:Falling_water_-_panoramio_(1).jpg
         - src: /images/architectuur/fallingwater-bos.jpg
           caption: Tussen de bomen
@@ -72,7 +72,7 @@ figures:
           caption: Hetzelfde huis, ander seizoen
           source: https://commons.wikimedia.org/wiki/File:STA60216.JPG
         - src: /images/architectuur/fallingwater-winter-2.jpg
-          caption: Winter, van dichterbij
+          caption: Winter, gezien door de besneeuwde bomen
           source: https://commons.wikimedia.org/wiki/File:STA60224.JPG
     fallingwater-interieur:
       images:
@@ -99,7 +99,7 @@ figures:
           caption: Bij nacht
           source: https://commons.wikimedia.org/wiki/File:A_View_of_the_Sydney_Opera_House_in_Australia_(48453308656).jpg
         - src: /images/architectuur/sydney-nacht-2.jpg
-          caption: Bij volle maan
+          caption: Bij avond, onder een bewolkte hemel
           source: https://commons.wikimedia.org/wiki/File:(1)Sydney_Opera_House.jpg
         - src: /images/architectuur/sydney-nacht-3.jpg
           caption: De schalen weerspiegeld in de haven
@@ -206,18 +206,18 @@ figures:
           caption: Voll Arkitekter, Mjøstårnet, Brumunddal, 2019
           source: https://commons.wikimedia.org/wiki/File:Narsot%C3%A5rnet_ved_Mj%C3%B8sa_01.jpg
         - src: /images/architectuur/mjostarnet-meer-2.jpg
-          caption: Vanaf de overkant van het Mjøsa-meer
+          caption: Dezelfde toren vanaf de weg bij Brumunddal
           source: https://commons.wikimedia.org/wiki/File:Narsot%C3%A5rnet_ved_Mj%C3%B8sa_02.jpg
         - src: /images/architectuur/mjostarnet-toren.jpg
           caption: De toren in zijn omgeving
           source: https://commons.wikimedia.org/wiki/File:Narsot%C3%A5rnet_IV.jpg
         - src: /images/architectuur/mjostarnet-portret.jpg
-          caption: De houten gevel van dichtbij
+          caption: De toren in de winter, met de balkons op de bovenste verdiepingen
           source: https://commons.wikimedia.org/wiki/File:Mj%C3%B8st%C3%A5rnet.jpg
     mjostarnet-bouw:
       images:
         - src: /images/architectuur/mjostarnet-bouw.jpg
-          caption: In aanbouw — het dragende houtskelet
+          caption: In aanbouw — de banier op de gevel noemt het het hoogste houten gebouw ter wereld
           source: https://commons.wikimedia.org/wiki/File:Mj%C3%B8st%C3%A5rnet1.jpg
     horyuji:
       images:

--- a/src/content/themes/art-nouveau-en-deco.mdx
+++ b/src/content/themes/art-nouveau-en-deco.mdx
@@ -11,15 +11,15 @@ figures:
     arcane-titelkaart:
       images:
         - src: /images/art-nouveau-en-deco/arcane-titelkaart.jpg
-          caption: Arcane, titelkaart — art-nouveau-portretten in een stalen patrijspoort, 2021
+          caption: Vi en Powder kijken uit over Piltover, Arcane, 2021
           source: https://www.netflix.com/title/81435684
     arcane-piltover:
       images:
         - src: /images/art-nouveau-en-deco/arcane-piltover-dak.jpg
-          caption: Piltover gezien vanaf de daken, Arcane, 2021
+          caption: Piltover van bovenaf — een plein diep onder de daken, Arcane, 2021
           source: https://www.netflix.com/title/81435684
         - src: /images/art-nouveau-en-deco/arcane-piltover-luchtschip.jpg
-          caption: Luchtschip boven Piltover, Arcane, 2021
+          caption: Portaal in Piltover — deco-geometrie, conceptart, Arcane, 2021
           source: https://www.netflix.com/title/81435684
     tassel:
       images:
@@ -151,13 +151,13 @@ figures:
     arcane-deco:
       images:
         - src: /images/art-nouveau-en-deco/arcane-deco-glasraam.jpg
-          caption: Glas-in-lood in Piltover — deco-geometrie, Arcane, 2021
-          source: https://www.netflix.com/title/81435684
-        - src: /images/art-nouveau-en-deco/arcane-raad.jpg
           caption: De raadzaal van Piltover, Arcane, 2021
           source: https://www.netflix.com/title/81435684
+        - src: /images/art-nouveau-en-deco/arcane-raad.jpg
+          caption: Powder in het atelier, Arcane, 2021
+          source: https://www.netflix.com/title/81435684
         - src: /images/art-nouveau-en-deco/arcane-deco-poort.png
-          caption: Portaal in Piltover — verticaliteit en symmetrie, Arcane, 2021
+          caption: Glas-in-lood in Piltover — verticaliteit en symmetrie, Arcane, 2021
           source: https://www.netflix.com/title/81435684
     arcane-zaun:
       images:
@@ -191,7 +191,7 @@ figures:
     powder:
       images:
         - src: /images/art-nouveau-en-deco/arcane-powder-atelier.jpg
-          caption: Powder in het atelier, Arcane, 2021
+          caption: Jinx, Arcane, 2021
           source: https://www.netflix.com/title/81435684
 
 videos:

--- a/src/content/themes/belgisch-experiment.mdx
+++ b/src/content/themes/belgisch-experiment.mdx
@@ -21,7 +21,7 @@ figures:
           caption: Rosetta, 1999 — affiche
           source: https://lesfilmsdufleuve.be/en/movies/rosetta/
         - src: /images/belgisch-experiment/dardenne-rosetta-3.jpg
-          caption: Rosetta op de caravansite, foto Christine Plenus
+          caption: Rosetta en Riquet aan tafel — foto Christine Plenus
           source: https://lesfilmsdufleuve.be/en/movies/rosetta/
     cripplewood:
       images:
@@ -42,7 +42,7 @@ figures:
           caption: Patrick Corillon, On the Track of St Eanswythe's Waterway, 2021 — Folkestone Triennial, foto Thierry Bal
           source: https://www.creativefolkestone.org.uk/artists/patrick-corillon-artworks/
         - src: /images/belgisch-experiment/corillon-eanswythe-2.jpg
-          caption: Corillon, On the Track of St Eanswythe's Waterway — detail van de reliekschrijn-installaties
+          caption: Corillon, On the Track of St Eanswythe's Waterway — een van de kastjes langs de route
           source: https://www.creativefolkestone.org.uk/artists/patrick-corillon-artworks/
         - src: /images/belgisch-experiment/corillon-eanswythe-3.jpg
           caption: Corillon, On the Track of St Eanswythe's Waterway — verdere installatie langs de waterloop
@@ -53,7 +53,7 @@ figures:
           caption: Marcel Broodthaers, Musée d'Art Moderne — Département des Aigles, 1968 tot 1972 — installatieoverzicht
           source: https://www.moma.org/collection/works/146967
         - src: /images/belgisch-experiment/broodthaers-aigles-2.jpg
-          caption: Musée d'Art Moderne — Département des Aigles — detailaanzicht
+          caption: Département des Aigles — een adelaar met de plaatjes uit de reeks, gereproduceerd op een boekomslag
           source: https://www.moma.org/collection/works/146967
         - src: /images/belgisch-experiment/broodthaers-aigles-3.jpg
           caption: Département des Aigles — installatieaanzicht bij Marian Goodman
@@ -99,7 +99,7 @@ figures:
     location:
       images:
         - src: /images/belgisch-experiment/op-de-beeck-location-1.jpg
-          caption: Hans Op de Beeck, Location (5), 2004 — interieur van het wegrestaurant
+          caption: Hans Op de Beeck, Location (5), 2004 — werktekening van de installatie
           source: https://hansopdebeeck.com/works/2004/location-5
         - src: /images/belgisch-experiment/op-de-beeck-location-2.jpg
           caption: Location (5) — uitzicht op de autosnelweg, perspectiefillusie van vier meter naar veertig centimeter
@@ -110,13 +110,13 @@ figures:
     logos:
       images:
         - src: /images/belgisch-experiment/logos-robot-1.jpg
-          caption: Logos M&M Robot Orchestra, Stichting Logos, Gent — Godfried-Willem Raes met de robots
+          caption: Logos M&M Robot Orchestra, Stichting Logos, Gent — het volledige orkest opgesteld in de Tetraëder
           source: https://www.logosfoundation.org/
         - src: /images/belgisch-experiment/logos-robot-2.jpg
-          caption: Logos M&M Robot Orchestra — concert in de Logos Tetraëder
+          caption: Logos M&M Robot Orchestra — een rij robots op wielen, elk een zelfontworpen instrument
           source: https://www.logosfoundation.org/
         - src: /images/belgisch-experiment/logos-robot-3.jpg
-          caption: Logos M&M Robot Orchestra — overzicht van het robotensemble
+          caption: Godfried-Willem Raes bij een van zijn robots — Stichting Logos, Gent
           source: https://www.logosfoundation.org/
 
 videos:

--- a/src/content/themes/beweging-en-dynamiek.mdx
+++ b/src/content/themes/beweging-en-dynamiek.mdx
@@ -70,13 +70,13 @@ figures:
           caption: Jean Tinguely, Homage to New York, 1960 — MoMA-tuin, 17 maart 1960
           source: https://www.moma.org/calendar/exhibitions/3369
         - src: /images/beweging-en-dynamiek/tinguely-2.jpg
-          caption: Fietswielen, motoren, een badkuip — alles van de schroothoop
+          caption: Jean Tinguely — machinesculptuur van schroot, motoronderdelen en een krokodillenschedel
           source: https://www.tinguely.ch/dam/jcr:a3deb258-7cd8-46a0-8e2b-e9f021369af3/011356Baur.jpg
         - src: /images/beweging-en-dynamiek/tinguely-3.jpg
-          caption: De machine vernietigt zichzelf, het publiek kijkt toe
+          caption: Jean Tinguely — assemblage met een antilopenschedel, een wiel en gebogen staal
           source: https://images.prismic.io/barnebys/abf31a74-b801-4708-8fe9-0833b2dc2a90_332L17025_9KRXM_restored.jpg
         - src: /images/beweging-en-dynamiek/tinguely-4.jpg
-          caption: Jean Tinguely en Yves Klein — de machine als medekunstenaar
+          caption: Jean Tinguely — een grote machinesculptuur, tentoonstellingszicht
           source: https://www.kunsthal.nl/media/filer_public_thumbnails/filer_public/85/85/85856562-c258-4baa-b6f5-e5fae9f54063/1988_jean_tinguely_last_collaboration_yves_klein.jpg__1689.0x1281.0_q85_crop_subsampling-2_upscale.jpg
     jansen:
       images:

--- a/src/content/themes/graffiti-en-street-art.mdx
+++ b/src/content/themes/graffiti-en-street-art.mdx
@@ -13,7 +13,7 @@ figures:
           caption: "'Taki 183' Spawns Pen Pals — The New York Times, 21 juli 1971"
           source: https://streetartnyc.org/blog/2015/06/29/the-legendary-taki-183-on-tagging-the-new-york-times-the-wall-on-207th-street-instafame-phantom-art-graffiti-and-more/
         - src: /images/graffiti-en-street-art/taki-2.jpg
-          caption: TAKI 183, tag, begin jaren 1970
+          caption: Demetrius, de schrijver achter TAKI 183, zet zijn tag — jaren na dato
           source: https://streetartnyc.org/blog/2015/06/29/the-legendary-taki-183-on-tagging-the-new-york-times-the-wall-on-207th-street-instafame-phantom-art-graffiti-and-more/
     philadelphia:
       images:

--- a/src/content/themes/licht-en-schaduw.mdx
+++ b/src/content/themes/licht-en-schaduw.mdx
@@ -14,13 +14,13 @@ figures:
           caption: Gerhard Richter, Domfenster, Köln, 2007 — lichtval op de vloer
           source: https://commons.wikimedia.org/wiki/Category:Richter_Window_in_the_Cologne_Cathedral
         - src: /images/licht-en-schaduw/richter-2.jpg
-          caption: Hetzelfde raam, frontaal — 11.263 vierkanten in 72 kleuren
+          caption: Hetzelfde raam van buitenaf, in de gotische tracering van de Dom
           source: https://commons.wikimedia.org/wiki/Category:Richter_Window_in_the_Cologne_Cathedral
         - src: /images/licht-en-schaduw/richter-3.png
           caption: Detail — geen lood, alleen siliconenkit
           source: https://www.derix.com/portfolio-items/richterfenster-koelner-dom
         - src: /images/licht-en-schaduw/richter-4.png
-          caption: Het raam in zijn architecturale context
+          caption: Het raam frontaal — 11.263 vierkanten in 72 kleuren
           source: https://publicdelivery.org/gerhard-richter-cathedral/
     sainte-chapelle:
       images:

--- a/src/content/themes/meerstemmigheid.mdx
+++ b/src/content/themes/meerstemmigheid.mdx
@@ -11,10 +11,10 @@ figures:
     erraji:
       images:
         - src: /images/meerstemmigheid/erraji-1.jpg
-          caption: Hassan Erraji, live in concert
+          caption: Hassan Erraji met zijn oed — studioportret
           source: https://bandonthewall.org/events/hassan-erraji/
         - src: /images/meerstemmigheid/erraji-2.jpg
-          caption: Hassan Erraji — albumhoes
+          caption: Hassan Erraji, live in concert
           source: https://www.deezer.com/en/artist/170876
     georgian:
       images:
@@ -44,7 +44,7 @@ figures:
     pythagoras:
       images:
         - src: /images/meerstemmigheid/pythagoras-1.png
-          caption: Pythagoras en de smid, houtsnede uit Franchino Gaffurio's Theorica Musicae, 1492
+          caption: Pythagoras en de smeden — handschriftillustratie bij Boethius' De musica
           source: https://commons.wikimedia.org/wiki/Category:Pythagoras_and_the_smithy
     guido:
       images:

--- a/src/content/themes/smaak-klasse-macht.mdx
+++ b/src/content/themes/smaak-klasse-macht.mdx
@@ -36,7 +36,7 @@ figures:
   normcore:
     images:
       - src: /images/smaak-klasse-macht/normcore.png
-        caption: Normcore — effen trui, witte sneaker, bewust onopvallend
+        caption: Normcore — effen shirt, jeans, bewust onopvallend
         source: https://thatchicfashionblog.wordpress.com/2014/08/18/normcore-is-anonymous-the-new-fashion-movement/
   hipster:
     images:
@@ -58,10 +58,10 @@ figures:
   warhol-bills:
     images:
       - src: /images/smaak-klasse-macht/warhol-dollars.png
-        caption: Andy Warhol, 200 One Dollar Bills, 1962
+        caption: Dollarbiljetten, elk door Andy Warhol gesigneerd — veilinglot
         source: https://www.invaluable.com/auction-lot/andy-warhol-pitsburg-1928-new-york-1987-32-times--83-c-ed94bb3a68?srsltid=AfmBOop02gV3ND2vPGH_dl3L_J9EF3tiAngYAEyO5a2soSJLtbxOKjbF
       - src: /images/smaak-klasse-macht/warhol-dollar.png
-        caption: Andy Warhol, 200 One Dollar Bills, Detail
+        caption: Andy Warhol, zeefdruk van één dollarbiljet op doek
         source: https://www.sothebys.com/en/slideshows/12-interpretations-of-andy-warhol
   white-cube:
     images:


### PR DESCRIPTION
## Wat verandert er

23 bijschriften rechtgezet, in negen hoofdstukken. **323 van 323 beelden zijn
daadwerkelijk bekeken** — alle dertien geschreven hoofdstukken, niets
overgeslagen.

Het patroon is telkens hetzelfde: **het bijschrift beschrijft de bestandsnaam of
de bronpagina, niet het beeld.** Bij de Arcane-groep en bij Tinguely was dat
systematisch.

Closes #63

### De vier uit het issue

| beeld | stond er | staat er nu |
|---|---|---|
| `logos-robot-1` | Godfried-Willem Raes met de robots | het volledige orkest opgesteld in de Tetraëder |
| `logos-robot-2` | concert in de Logos Tetraëder | een rij robots op wielen, elk een zelfontworpen instrument |
| `logos-robot-3` | overzicht van het robotensemble | Godfried-Willem Raes bij een van zijn robots |
| `dardenne-rosetta-3` | Rosetta op de caravansite | Rosetta en Riquet aan tafel |

De identificatie van Raes is los bevestigd: `logos-3.png` in
`instrumentontwikkeling` toont dezelfde man met bijschrift "Oprichter
Godfried-Willem Raes". "gwr" in de bestandsnaam van `logos-robot-1` is
waarschijnlijk hoe het portretbijschrift daar terechtkwam.

### De negentien uit de sweep

Vier daarvan zijn geen bijschriftfout maar een **verkeerde werkidentificatie**:

- **Tinguely** (`beweging-en-dynamiek`) — `tinguely-2`, `-3` en `-4` heten geen
  van drieën *Homage to New York*. Erger: bij `-3` beloofde het bijschrift "de
  machine vernietigt zichzelf, het publiek kijkt toe", terwijl het beeld een
  studio- of veilingopname is met assemblage en antilopenschedel. Geen publiek,
  geen vernietiging.
- **Warhol** (`smaak-klasse-macht`) — géén van beide beelden is *200 One Dollar
  Bills*. `warhol-dollars` is een veilinglot van door Warhol gesigneerde
  biljetten, `warhol-dollar` een losse zeefdruk van één biljet.
- **Pythagoras** (`meerstemmigheid`) — geen houtsnede uit Gaffurio's *Theorica
  Musicae* (1492) maar een handschriftillustratie bij Boëthius' *De musica*. Zie
  hieronder; dit raakte een deck.
- **TAKI 183** (`graffiti-en-street-art`) — `taki-2` is geen tag uit de vroege
  jaren zeventig maar een recente foto van Demetrius die TAKI op een blocnote
  schrijft.

Twee paren stonden **omgewisseld**: `richter-2`/`richter-4` in `licht-en-schaduw`
en `erraji-1`/`erraji-2` in `meerstemmigheid`.

Zes **Arcane**-bijschriften in `art-nouveau-en-deco` volgden de bestandsnaam:
`arcane-titelkaart` toont Vi en Powder op het dak, `arcane-raad` toont Powder in
het atelier, `arcane-powder-atelier` toont Jinx op straat, enzovoort.

Vijf in `architectuur-en-bouwprincipes` noemden iets dat niet in beeld staat —
"vanaf de beek" zonder water, "bij volle maan" zonder maan, "vanaf de overkant
van het Mjøsa-meer" zonder meer.

Plus drie in `belgisch-experiment` (een boekomslag als installatiedetail, een
werktekening als interieurfoto, de wijdste opname van drie als "detail").

## Een fout die ik gisteren zelf heb geïntroduceerd

De Pythagoras-vondst raakt PR #62, van gisteren. Die voegde aan het
meerstemmigheid-deck een stille beeldslide toe met als sprekersnotitie:

> Vraag: wat gebeurt hier, en waarom staan er **getallen bij die hamers**?
> Pythagoras en de smid, **houtsnede uit Franchino Gaffurio's Theorica Musicae,
> 1492**.

Beide kloppen niet. Het is een Boëthius-handschrift, en er staan geen getallen op
de hamers — de klas werd dus naar iets gevraagd wat niet in beeld staat. Ook de
vervolgslide antwoordde "de getallen op de hamers zijn gewichten".

Beide notities zijn hier herschreven naar wat het beeld wél toont: Pythagoras met
zijn naam erboven, drie smeden op één aambeeld, en onderaan een schrijver en een
harpspeler — meten, noteren, spelen, op één bladzijde. Het verhaal over de
hamergewichten blijft, nu met de kanttekening dat niemand weet of het echt zo
gebeurd is. Dat het beeld uit een Boëthius-handschrift komt maakt de slide
bovendien sterker: de notitie ging al over Boëthius als het standaardwerk waarmee
kathedraalscholen polyfonie onderwezen.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- `npm run check:chapters` → 7 bevindingen voor, 7 na — ongewijzigd, want dit
  issue raakt geen `source:`-velden of ongebruikte keys
- `npm run check:slides` → alle 5 decks volledig
- Render: alle 23 nieuwe bijschriften staan in de gerenderde HTML, nul missers.
- Diffvorm: 8 hoofdstukken, 5 `sources.json`, 1 deck. Working tree leeg.

## Wat is gemeld en niet aangeraakt

Vijf dingen waar de worker terecht is gestopt in plaats van te gokken. Elk krijgt
een eigen issue:

1. **`sainte-chapelle-2` is waarschijnlijk Vincennes, niet Parijs** — open
   esplanade, classicistische vleugel ernaast, en de centrale flèche ontbreekt.
   Dat is geen bijschrift maar een verkeerd gebouw in een dragend voorbeeld.
2. **`sainte-chapelle-3`** toont een radiaal blauw roosvenster; de Sainte-Chapelle
   heeft een flamboyant, vlamvormig rood venster, en de bronpagina spreekt van
   *negentiende*-eeuws glas waar het bijschrift 15de-eeuws zegt.
3. **Twee beelden die de tekst noemt bestaan niet** in `art-nouveau-en-deco`: de
   Arcane-titelkaart en het luchtschip. En `fig:powder` wijst naar het
   Jinx-beeld terwijl de tekst over Powder in het atelier gaat.
4. **Drie beelden staan 90° gedraaid** op de site: `sagrada-nacht-2.jpg`,
   `horyuji-tempelhof.jpg`, `horyuji-dakdetail.jpg`. Geen bijschriftfout, wel
   zichtbaar kapot.
5. **Manifest-gaten**: drie mappen hebben geen `sources.json`, de Arcane-beelden
   staan in geen enkel manifest, en `charlier-vernissage-1/2` staan er als wees
   in terwijl het hoofdstuk de `.png`-versies gebruikt.

## Waarom geen check dit vangt

`check:chapters` controleert of het bestand bestaat en of er een `source:` staat.
Of het bijschrift bij het beeld hoort, kan alleen iemand die kijkt. Alle 23 fouten
stonden live, hadden een geldige bron en een groene build.
