### PR TITLE
Accentkleur kleurt de hele pagina, uit één bron (#55)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -33,7 +33,10 @@ const themes = defineCollection({
     customLayout: z.string().optional(),
     customStyles: z.string().optional(),
     customHeader: z.boolean().optional(),
-    accentColor: z.string().optional(),
+    // Zeshexadecimale notatie, want ThemeLayout zet deze waarde rechtstreeks in
+    // een `<style>` op `:root` (#55). Het schema is daarmee de enige plek waar
+    // die vorm afgedwongen wordt.
+    accentColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'accentColor moet #rrggbb zijn').optional(),
     figures: z.record(z.string(), z.object({ images: z.array(figureImage) }).strict()).optional(),
     videos: z.record(z.string(), z.object({
       youtube: z.string().length(11),

--- a/src/layouts/ThemeLayout.astro
+++ b/src/layouts/ThemeLayout.astro
@@ -83,6 +83,23 @@ const videos = (theme.data as any).videos ?? null;
   {customStylesUrl && (
     <link slot="head" rel="stylesheet" href={customStylesUrl} />
   )}
+  {/*
+    De accentkleur van het hoofdstuk op `:root`, en dus op de hele pagina — ook
+    op de site-header, die buiten `.theme-grid` valt (#55). Stond hier eerder
+    inline op `.theme-grid`; daardoor kleurde de cursustekst wel mee en de header
+    niet, en hielden twee hoofdstukken er een tweede kopie in hun eigen
+    stylesheet op na. Die kopieën zijn weg.
+
+    Op `:root` werkt de afleiding van `--color-accent-soft` in tokens.css
+    vanzelf mee: een `color-mix()` wordt berekend op het element waar ze
+    gedeclareerd staat, en dat is hier hetzelfde element.
+
+    De waarde komt uit de frontmatter en is door het schema op #rrggbb
+    vastgelegd (`src/content.config.ts`).
+  */}
+  {theme.data.accentColor && (
+    <style slot="head" is:global set:html={`:root{--color-accent:${theme.data.accentColor}}`} />
+  )}
   <script is:inline define:vars={{ figures, videos }}>
     if (figures) window.__figures = figures;
     if (videos) window.__videos = videos;
@@ -124,10 +141,7 @@ const videos = (theme.data as any).videos ?? null;
     }
   </style>
 
-  <div
-    class="theme-grid"
-    style={theme.data.accentColor ? `--color-accent: ${theme.data.accentColor}` : undefined}
-  >
+  <div class="theme-grid">
     <aside class="theme-grid__sidebar">
       <ChapterSidebar
         currentThemeId={theme.id}
@@ -256,12 +270,6 @@ const videos = (theme.data as any).videos ?? null;
 <style>
   /* ---- Grid ---- */
   .theme-grid {
-    /* De inline `style` hierboven zet `--color-accent` uit de frontmatter.
-       `--color-accent-soft` moet daar opnieuw uit afgeleid worden: een
-       `color-mix()` wordt berekend op het element waar ze gedeclareerd is,
-       dus de versie op `:root` in tokens.css blijft bij de globale accent
-       staan en zou hier de verkeerde kleur geven. */
-    --color-accent-soft: color-mix(in srgb, var(--color-accent) 8%, transparent);
     display: grid;
     grid-template-columns: 1fr;
     max-width: 1280px;

--- a/src/styles/themes/inleiding.css
+++ b/src/styles/themes/inleiding.css
@@ -1,11 +1,8 @@
 /* src/styles/themes/inleiding.css */
 
 :root {
-  /* Ducttape-geel vervangt fuchsia op deze pagina. Moet gelijk blijven aan
-     `accentColor:` in de frontmatter — zie de noot in
-     perspectief-en-ruimte.css over waarom die kopie hier staat.
-     `--color-accent-soft` wordt afgeleid (tokens.css). */
-  --color-accent:      #E8D547;
+  /* Ducttape-geel staat in `accentColor:` in de frontmatter en wordt door
+     ThemeLayout op `:root` gezet (#55). Hier dus geen kopie. */
 
   /* Iets warmere achtergrond — galeriemuur, niet zwart */
   --color-bg:          #1c1a17;

--- a/src/styles/themes/perspectief-en-ruimte.css
+++ b/src/styles/themes/perspectief-en-ruimte.css
@@ -1,14 +1,10 @@
 /* src/styles/themes/perspectief-en-ruimte.css */
 
 :root {
-  /* Moet gelijk blijven aan `accentColor:` in de frontmatter van het
-     hoofdstuk. Die waarde zet ThemeLayout inline op `.theme-grid` en dekt
-     dus de cursustekst; deze kopie dekt wat daarbuiten valt — de
-     site-header gebruikt `--color-accent` ook. Ze zijn hier ooit uit
-     elkaar gelopen (#44): de frontmatter zei #3b85ca, dit bestand #3B4CCA,
-     en de pagina toonde allebei. `--color-accent-soft` staat er niet meer
-     bij; die wordt afgeleid (tokens.css). */
-  --color-accent:      #3b85ca;
+  /* Geen `--color-accent` hier: die komt uit `accentColor:` in de frontmatter
+     en wordt door ThemeLayout op `:root` gezet (#55). Eén bron. Ooit stond hij
+     hier ook, en toen liepen de twee uit elkaar — de frontmatter zei #3b85ca,
+     dit bestand #3B4CCA, en de pagina toonde ze allebei (#44). */
   --color-bg:          #1a1a1a;
 }
 


### PR DESCRIPTION
## Wat verandert er

De accentkleur uit de frontmatter kleurt nu de hele pagina in plaats van alleen
de cursustekst. `ThemeLayout` zet hem op `:root` via een `<style>` in de head, in
plaats van inline op `.theme-grid`.

Dat was de eigenlijke oorzaak van #44. `.theme-grid` is de wrapper om de
cursustekst; de site-header valt daarbuiten en gebruikt `--color-accent` ook
(`SiteHeader.astro:37`). Gevolg: bij vijf van de zeven hoofdstukken met een eigen
accent was de header roze en de tekst gekleurd. De twee hoofdstukken die dat wél
goed hadden — `inleiding` en `perspectief-en-ruimte` — losten het op met een
tweede kopie op `:root` in hun eigen stylesheet, en precies daar liepen de
waarden uit elkaar.

**Beide kopieën zijn weg. De frontmatter is de enige bron.**

Een meevaller: de afleiding van `--color-accent-soft` in `tokens.css` werkt nu
vanzelf mee. Een `color-mix()` wordt berekend op het element waar ze gedeclareerd
staat, en `--color-accent` staat nu op datzelfde `:root`. De workaround die #44
daarvoor op `.theme-grid` moest zetten, kon vervallen.

**Het schema dwingt `#rrggbb` af.** De waarde gaat rechtstreeks een `<style>` in,
dus de vorm hoort ergens vast te liggen; `src/content.config.ts` is de enige plek
waar dat kan. Alle zeven bestaande waarden voldoen — `astro check` groen is daar
het bewijs van.

Closes #55

## Wat er zichtbaar verandert

Zeven hoofdstukken hebben een `accentColor`. Vijf daarvan krijgen nu een
gekleurde header waar die roze was:

| hoofdstuk | accent |
|---|---|
| `art-nouveau-en-deco` | `#c9a227` |
| `beweging-en-dynamiek` | `#e23b2e` |
| `instrumentontwikkeling` | `#C9722E` |
| `licht-en-schaduw` | `#d49a3c` |
| `meerstemmigheid` | `#862D3F` |

`inleiding` en `perspectief-en-ruimte` hadden al een gekleurde header en houden
dezelfde kleur — alleen komt die nu uit de frontmatter in plaats van uit hun
stylesheet. De zestien hoofdstukken zonder `accentColor` veranderen niet.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- Geverifieerd in de gebouwde HTML dat de regel echt landt en de juiste waarde
  draagt:

```
perspectief-en-ruimte   :root{--color-accent:#3b85ca}
inleiding               :root{--color-accent:#E8D547}
meerstemmigheid         :root{--color-accent:#862D3F}
beweging-en-dynamiek    :root{--color-accent:#e23b2e}   ← geen eigen stylesheet
symboliek               0 voorkomens                     ← stub zonder accentColor
```

Dat laatste paar is het punt: een hoofdstuk zonder eigen stylesheet krijgt de
kleur nu ook, en een hoofdstuk zonder `accentColor` krijgt geen regel.

- In `src/styles/**` staat nog precies één declaratie van elk van de twee tokens,
  allebei in `tokens.css`.
- Diffvorm: 4 bestanden, working tree leeg.

## Wat niet is vastgesteld

**Hoe het eruitziet.** Er was geen scherm. Dit verandert een zichtbare kleur op
vijf pagina's tegelijk, en of een amberkleurige of donkerrode header naast de
rest van de site werkt, is precies het soort vraag dat een build niet beantwoordt.
Kijk in het bijzonder naar `meerstemmigheid` (`#862D3F`, donker en verzadigd) en
`beweging-en-dynamiek` (`#e23b2e`, fel rood) — dat zijn de twee die het verst van
de globale roze af liggen.

Bevalt het niet, dan is de andere uitkomst van dit issue — de header bewust altijd
roze, als constante van de site — nog steeds beschikbaar, en dan gaan de twee
`:root`-kopieën alsnog weg. De duplicatie is hoe dan ook opgelost; alleen de
richting is omkeerbaar.
