### PR TITLE
Introduceer de Guerrilla Girls waar ze vallen (#59)

### DIFF
--- a/src/content/themes/smaak-klasse-macht.mdx
+++ b/src/content/themes/smaak-klasse-macht.mdx
@@ -266,7 +266,7 @@ Het beeld is niet helemaal somber. Instituten kunnen veranderen. Toen Tate Moder
 
 Het idee erachter: niet elk werk hoeft "meesterwerk" te zijn. Sommige werken zijn er omdat ze een vraag stellen, omdat ze de bezoeker laten kijken naar het werk ernaast op een andere manier. Dat was in 2000 echt vernieuwend. Inmiddels is het normaal geworden. MoMA herhing zijn collectie op die manier in 2019. Het Stedelijk in Amsterdam volgde. Documenta 14 verschoof het centrum naar Athene. Overal hetzelfde patroon: meer vrouwen, meer niet-westerse kunstenaars, meer dialoog en minder canon.
 
-De kritiek van de Guerrilla Girls, die we in het vorige hoofdstuk zagen, heeft écht effect gehad. In het MoMA hangen nu meer vrouwen. Tate toont meer niet-westerse kunstenaars. Dat is geen schijn — dat zijn echte verschuivingen.
+De kritiek van de Guerrilla Girls heeft écht effect gehad. Dat anonieme collectief ontstond in 1985, nadat datzelfde MoMA een groot overzicht van internationale schilder- en beeldhouwkunst had samengesteld met dertien vrouwen op honderdnegenenzestig kunstenaars. Sindsdien plakken ze affiches vol cijfers die iedereen kan natellen, onder de namen van dode kunstenaressen. In het MoMA hangen nu meer vrouwen. Tate toont meer niet-westerse kunstenaars. Dat is geen schijn — dat zijn echte verschuivingen.
 
 Maar kijk hoe dat werkt. De instituten verdwijnen niet. Ze passen zich aan. MoMA blijft MoMA, alleen hangt er nu meer diverse kunst. Tate blijft Tate, maar toont ander werk. De macht om te beslissen *welke* vrouwen en *welke* niet-westerse kunstenaars getoond worden, zit nog steeds bij dezelfde instituten.
 


### PR DESCRIPTION
## Wat verandert er

`smaak-klasse-macht` verwees naar de Guerrilla Girls als iets wat de lezer al
kende:

> De kritiek van de Guerrilla Girls, ~~die we in het vorige hoofdstuk zagen~~,
> heeft écht effect gehad.

Dat hoofdstuk bestaat niet. Guerrilla Girls komen in geen enkel ander hoofdstuk
voor — niet in `graffiti-en-street-art` (het hoofdstuk dat hier in de module aan
voorafgaat), en niet in de stubs. De lezer werd verondersteld iets te kennen wat
nergens is uitgelegd, en de alinea ging vervolgens verder alsof dat zo was.

Ze staan er nu zelf, in twee zinnen:

> De kritiek van de Guerrilla Girls heeft écht effect gehad. Dat anonieme
> collectief ontstond in 1985, nadat datzelfde MoMA een groot overzicht van
> internationale schilder- en beeldhouwkunst had samengesteld met dertien vrouwen
> op honderdnegenenzestig kunstenaars. Sindsdien plakken ze affiches vol cijfers
> die iedereen kan natellen, onder de namen van dode kunstenaressen. In het MoMA
> hangen nu meer vrouwen.

Closes #59

## Waarom introduceren en niet schrappen

Het probleem was niet de verwijzing maar dat de lezer het collectief niet kent.
De verwijzing weghalen laat een naam staan die de alinea nodig heeft: de hele
passage gaat erover dat instituten zich aanpassen aan kritiek zonder macht af te
staan, en zonder te weten wat die kritiek wás, draagt dat argument niet.

De plaatsing is bovendien een meevaller: de vorige alinea eindigt op *"MoMA
herhing zijn collectie op die manier in 2019"*, en de directe aanleiding voor het
ontstaan van de Guerrilla Girls was een MoMA-tentoonstelling. Datzelfde instituut,
vierendertig jaar ertussen. De alinea die erop volgt — *"De Guerrilla Girls hebben
gewerkt — en MoMA bleef MoMA"* — landt daardoor harder.

## Feitencontrole

Elk cijfer nagekeken vóór het opgeschreven werd, en niets opgenomen wat ik niet
in een bron terugvond:

- **1985, anoniem, pseudoniemen van kunstenaressen uit het verleden** —
  [Britannica](https://www.britannica.com/topic/Guerrilla-Girls)
- **De aanleiding: MoMA, *An International Survey of Painting and Sculpture*, 13
  vrouwen op 169 kunstenaars** — Britannica
- **Affiches met publiek beschikbare cijfers** —
  [National Museum of Women in the Arts](https://nmwa.org/gallery-labels-guerrilla-girls/)

Bewust *niet* opgenomen: de gorillamaskers. Die zijn algemeen bekend en
waarschijnlijk juist, maar ze kwamen niet in de bronnen die ik heb nagekeken, en
dan schrijf ik ze niet op. Wie ze erbij wil, kan dat in één zin doen — met een
bron erbij.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, site + 5 decks
- `npm run check:chapters -- smaak-klasse-macht` → in orde (1 aanvaard: de
  ontbrekende `source:` bij `cattelan-parody.png`, uit #53)
- Diffvorm: 1 bestand, 1 alinea. Working tree leeg.
- Geen render-check: geen scherm. Er is geen markup gewijzigd, alleen platte
  tekst binnen een bestaande alinea.

## Register

`docs/REDACTIE.md`: courant Nederlands, geen decoratieve metafoor, en bij een
algemene persoon de je-vorm — vandaar "cijfers die iedereen kan natellen" en niet
een constructie met "zijn". Kritiek is hier geen toegevoegde laag maar het
onderwerp van de passage zelf, dus dat blok van REDACTIE speelt niet.
