### PR TITLE
duet-layout: twee fragmenten naast elkaar (#61)

### DIFF
--- a/.claude/skills/slidev/SKILL.md
+++ b/.claude/skills/slidev/SKILL.md
@@ -192,6 +192,7 @@ Wat er nu is in `slides/theme/layouts-base/layouts/`:
 | `image` | één beeld, volle slide (`backgroundSize: contain` voor werken) |
 | `image-left` / `image-right` | beeld naast tekst |
 | `compare` | twee beelden naast elkaar, `left:` en `right:` — **geen slot**, zie hieronder |
+| `duet` | twee *fragmenten* naast elkaar, `left:`/`right:` als `{ id, label }` — voor een hoorbare vergelijking; heeft wél een slot voor de vraag erboven |
 | `triptych` | drie (of twee/vier) beelden op één rij, `images:` + optioneel `captions:`, `reveal: true` voor één per klik |
 | `detail` | één werk groot (`image:`) plus zijn uitsneden (`details:`) — voor een figuurgroep die geen drie werken is maar een werk plus crops |
 | `paired-reveal` | tekststappen links, wisselend beeld rechts — per klik het volgende beeld uit `images:` |
@@ -217,7 +218,10 @@ zonder waarschuwing. `triptych` heeft er wél een, plus `captions:`. Die
 asymmetrie is precies omgekeerd aan wat je verwacht, en ze kost je een halve dag
 als je haar pas ontdekt nadat je de bijschriften geschreven hebt. Wil je bij een
 `compare` iets zeggen, dan gaat dat naar de sprekersnotitie — wat meestal ook de
-betere plek is (§1), maar het hoort een keuze te zijn.
+betere plek is (§1), maar het hoort een keuze te zijn. `duet` — de
+fragmentvariant van `compare` — heeft om die reden bewust wél een slot: op een
+vergelijkingsslide hoort de vraag van de docent boven de twee kanten te kunnen
+staan (#61).
 
 Drie dingen om niet mis te doen in een eigen layout:
 
@@ -269,6 +273,13 @@ site hetzelfde fragment.
   component zichtbaar `Onbekend fragment: <id>` in het rood — dat is opzet, zodat
   een typo in de les niet als lege plek verschijnt.
 - `label` weglaten en de titel uit de cursustekst wordt gebruikt.
+
+Moeten er **twee** fragmenten naast elkaar — hetzelfde stuk in twee uitvoeringen,
+vóór en ná een ingreep — gebruik dan `layout: duet` (§5) en niet twee
+`CourseVideoInline`'s in een handgeschreven flex-div. Die laatste vorm vraagt een
+`flex: 1`-wrapper per speler, een lege `style`-prop (anders krijg je 60% van 50%)
+en een bijschrift dat je met de hand als `<p class="meta-quiet">` moet
+onderhangen.
 
 Voeg je een video toe aan een hoofdstuk, draai dan `npm run sync:videos` voor je
 het deck opent. `npm run build:slides` doet dat zelf.

--- a/slides/README.md
+++ b/slides/README.md
@@ -21,7 +21,7 @@ slides/
 Elk hoofdstuk krijgt zijn **eigen visuele thema** onder `theme/` — het draagt de
 sfeer van dat hoofdstuk, niet die van de vorige les. Daarnaast trekt een deck het
 **`layouts-base`-addon** binnen voor de gedeelde extra layouts (`compare`,
-`triptych`, `detail`, `paired-reveal`, `quadrants`, `breathe`) en de
+`duet`, `triptych`, `detail`, `paired-reveal`, `quadrants`, `breathe`) en de
 videocomponenten:
 
 ```yaml
@@ -31,6 +31,25 @@ addons:
   - ./theme/layouts-base
 ---
 ```
+
+`duet` is de fragment-tegenhanger van `compare`: twee `CourseVideoInline`-spelers
+naast elkaar met een label per kant, declaratief in de frontmatter, plus een slot
+voor de vraag erboven.
+
+```yaml
+---
+layout: duet
+left:  { id: meerstemmigheid/leonin,  label: "Léonin · ca. 1170 · twee stemmen" }
+right: { id: meerstemmigheid/perotin, label: "Pérotin · ca. 1200 · vier stemmen" }
+---
+
+## Viderunt omnes · twee keer
+```
+
+De spelers zijn breedte-gebonden en dus kleiner dan één enkele speler; dat is de
+prijs van gelijktijdigheid. `slides/check-coverage.mjs` leest deze twee id's uit
+de frontmatter mee, zodat een fragment dat alleen in een `duet` staat gewoon
+meetelt in de dekking.
 
 > **Let op de paden.** `theme:` wordt door Slidev resolved t.o.v. de map
 > van `slides.md` zelf (vandaar `../`), maar `addons:` t.o.v. de parent
@@ -48,7 +67,7 @@ custom properties op `:root` definiëren wil het addon correct renderen:
 | `--color-text`, `--color-text-quiet` | meta-regel in quadrant |
 | `--color-rule` *(optioneel)* | randen rond quadrants, detail-uitsneden en paired-reveal-beeld — valt terug op `--color-text` |
 | `--space-sm`, `--space-md`, `--space-lg`, `--space-xl` | gaps en padding |
-| `--font-mono`, `--step--1` | meta-regel in quadrant, bijschriften in triptych en detail |
+| `--font-mono`, `--step--1` | meta-regel in quadrant, bijschriften in triptych en detail, labels in duet |
 | `--breathe-from`, `--breathe-to` *(optioneel)* | begin- en eindkleur van de grond onder `layout: breathe`; optioneel `--breathe-via-1` / `--breathe-via-2` voor de tussenstanden en `--breathe-duration` (standaard 75s). Zonder deze tokens staat de grond stil op `--color-bg` — geen effect in plaats van een verkeerd effect |
 
 Het basis-tokenset (`--color-bg`, `--color-text`, typografie-stapel,

--- a/slides/check-coverage.mjs
+++ b/slides/check-coverage.mjs
@@ -41,6 +41,15 @@ const IMAGE_RE = /[^\s"'`()[\]{}<>,]*\/images\/[A-Za-z0-9._\-/]+/g;
 const VIDEO_RE =
   /<CourseVideo(?:Inline)?\b[^>]*\bid\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*['"]([^'"]*)['"]\s*\})/g;
 
+// `layout: duet` (#61) zet zijn twee fragmenten niet in een tag maar in de
+// frontmatter — `left: { id: meerstemmigheid/leonin, label: "…" }`, of dezelfde
+// mapping in blokvorm. Zonder deze tweede vangst telt een duet-slide als
+// "video ontbreekt" terwijl het fragment gewoon speelt.
+// `compare` gebruikt dezelfde propnamen voor beeldpaden, maar die zijn een
+// scalair en geen mapping, dus die matchen hier niet.
+const DUET_SIDE_RE = /^[ \t]*(?:left|right)[ \t]*:[ \t]*(?:\{[^}]*\}|(?:\n[ \t]+\S.*)+)/gm;
+const DUET_ID_RE = /\bid[ \t]*:[ \t]*["']?([^\s,"'}]+)/;
+
 function readSiteBase() {
   try {
     const config = readFileSync(join(projectRoot, 'astro.config.mjs'), 'utf8');
@@ -86,6 +95,10 @@ function deckReferences(raw) {
   const videos = new Set();
   for (const match of source.matchAll(VIDEO_RE)) {
     const id = match[1] ?? match[2] ?? match[3];
+    if (id) videos.add(id.trim());
+  }
+  for (const [side] of source.matchAll(DUET_SIDE_RE)) {
+    const id = DUET_ID_RE.exec(side)?.[1];
     if (id) videos.add(id.trim());
   }
   return { images, videos, wrongPrefix };

--- a/slides/meerstemmigheid/slides.md
+++ b/slides/meerstemmigheid/slides.md
@@ -297,28 +297,12 @@ referentiewerk waar alle kathedraalscholen mee werkten.
 -->
 
 ---
+layout: duet
+left:  { id: meerstemmigheid/leonin,  label: "Léonin · ca. 1170 · twee stemmen" }
+right: { id: meerstemmigheid/perotin, label: "Pérotin · ca. 1200 · vier stemmen" }
+---
 
 ## Viderunt omnes · twee keer
-
-<div style="display: flex; gap: var(--space-md); align-items: flex-start; margin-top: var(--space-md);">
-
-<div style="flex: 1;">
-
-<CourseVideoInline id="meerstemmigheid/leonin" />
-
-<p class="meta-quiet" style="margin-top: var(--space-xs);">Léonin · ca. 1170 · twee stemmen</p>
-
-</div>
-
-<div style="flex: 1;">
-
-<CourseVideoInline id="meerstemmigheid/perotin" />
-
-<p class="meta-quiet" style="margin-top: var(--space-xs);">Pérotin · ca. 1200 · vier stemmen</p>
-
-</div>
-
-</div>
 
 <!--
 Hetzelfde stuk, dertig jaar later. Links Early Music Consort of London, David Munrow;

--- a/slides/theme/layouts-base/layouts/duet.vue
+++ b/slides/theme/layouts-base/layouts/duet.vue
@@ -1,0 +1,64 @@
+<!--
+  Twee fragmenten naast elkaar, elk met een eigen label, om ze in de les tegen
+  elkaar aan te zetten.
+
+  Bestaat omdat `compare` twee *beelden* doet en er voor twee *spelers* alleen
+  het handgeschreven flex-patroon was: elke speler in een eigen `flex: 1`-wrapper
+  (de `style`-prop moet dan leeg blijven, anders krijg je 60% van 50%) met het
+  bijschrift met de hand als `<p class="meta-quiet">` eronder. Drie niveaus
+  geneste HTML in een markdownbestand voor wat `compare` voor beelden in vier
+  frontmatterregels doet — en zonder het label per kant dat de vergelijking pas
+  leesbaar maakt (#39, #61).
+
+  Gebruik:
+    ---
+    layout: duet
+    left:  { id: meerstemmigheid/leonin,  label: "Léonin · ca. 1170 · twee stemmen" }
+    right: { id: meerstemmigheid/perotin, label: "Pérotin · ca. 1200 · vier stemmen" }
+    ---
+
+    ## Optionele kop — de vraag die de docent stelt
+
+  Anders dan `compare` heeft deze layout wél een slot: op een vergelijkingsslide
+  hoort de vraag boven de twee kanten te kunnen staan.
+
+  `id` is `<theme-id>/<video-key>`, net als bij CourseVideo(Inline); een key die
+  niet bestaat rendert zichtbaar rood in plaats van als lege plek. `label` is
+  optioneel — laat je hem weg, dan blijft de regel onder die kant leeg.
+-->
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import CourseVideoInline from '../components/CourseVideoInline.vue'
+
+interface Side {
+  id: string
+  label?: string
+}
+
+const props = defineProps<{
+  left: Side
+  right: Side
+}>()
+
+const slots = useSlots()
+const hasHeader = computed(() => !!slots.default)
+
+// Een ontbrekende kant valt terug op een lege id: CourseVideoInline rendert dan
+// zichtbaar rood `Onbekend fragment:` in plaats van een lege kolom. Een typo in
+// de frontmatter (`rigth:`) mag geen stille halve slide opleveren.
+const sides = computed(() => [props.left, props.right].map(side => side ?? { id: '' }))
+</script>
+
+<template>
+  <div class="slidev-layout duet" :class="{ 'duet--headed': hasHeader }">
+    <header v-if="hasHeader" class="duet-header">
+      <slot />
+    </header>
+    <div class="duet-row">
+      <figure v-for="(side, i) in sides" :key="i" class="duet-panel">
+        <CourseVideoInline :id="side.id" />
+        <figcaption v-if="side.label" class="duet-label">{{ side.label }}</figcaption>
+      </figure>
+    </div>
+  </div>
+</template>

--- a/slides/theme/layouts-base/styles/layouts.css
+++ b/slides/theme/layouts-base/styles/layouts.css
@@ -1,6 +1,7 @@
 /* ────────────────────────────────────────────────────────────────────
    layouts-base — gedeelde structurele regels voor:
      layout: compare        (twee beelden naast elkaar)
+     layout: duet           (twee fragmenten naast elkaar, met label)
      layout: triptych       (drie beelden op één rij)
      layout: detail         (één werk groot + zijn uitsneden)
      layout: paired-reveal  (tekst links, beeld dat per klik switcht)
@@ -243,6 +244,50 @@
   background-size: contain;
   min-height: 0;
   min-width: 0;
+}
+
+/* ── DUET — twee fragmenten naast elkaar, elk met een label, optioneel
+     met een kop erboven. Zie duet.vue.
+
+     Géén eigen padding: de spelers erven die van het thema, zodat de kop
+     op dezelfde lijn staat als op elke andere slide van het deck. De
+     spelers zijn dus breedte-gebonden — twee 16:9-kaders naast elkaar
+     halen ongeveer 80% van de hoogte van één enkele speler. Dat is de
+     prijs van gelijktijdigheid, en die is hier het punt. ───────────── */
+.slidev-layout.duet {
+  display: grid;
+  grid-template-rows: 1fr;
+  gap: var(--space-lg);
+}
+.slidev-layout.duet.duet--headed {
+  grid-template-rows: auto 1fr;
+}
+.slidev-layout.duet .duet-header h2 {
+  margin-bottom: 0;
+}
+.slidev-layout.duet .duet-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-md);   /* zelfde tussenruimte als compare — breedte is hier schaars */
+  align-items: center;
+  min-height: 0;
+}
+.slidev-layout.duet .duet-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin: 0;
+  min-width: 0;
+  min-height: 0;
+}
+.slidev-layout.duet .duet-label {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-text-quiet);
+  line-height: 1.4;
 }
 
 /* ── PAIRED-REVEAL — links tekst (v-clicks per bullet),


### PR DESCRIPTION
## Wat verandert er

`duet` in `layouts-base`: twee fragmenten naast elkaar, elk met een eigen label.
Toegepast op het geval dat erom vroeg — Léonins en Pérotins *Viderunt omnes* in
het meerstemmigheid-deck.

**23 regels markdown met drie niveaus geneste HTML worden 7 regels frontmatter:**

```yaml
layout: duet
left:  { id: meerstemmigheid/leonin,  label: "Léonin · ca. 1170 · twee stemmen" }
right: { id: meerstemmigheid/perotin, label: "Pérotin · ca. 1200 · vier stemmen" }
```

Dat was het bewijs dat #39 opleverde: bij twee spelers moest elke speler in een
eigen `flex: 1`-wrapper, met de `style`-prop leeg (anders krijg je 60% van 50%)
en het bijschrift met de hand als `<p class="meta-quiet">`, want er was geen
captionmechanisme. Plus geen label-per-kant, wat de vergelijking pas leesbaar
maakt.

**Met headerslot**, anders dan `compare`. Die val is in #39 ontdekt — een kop op
een `compare`-slide verdwijnt zonder waarschuwing. `duet` volgt het
`triptych`-patroon met een `duet--headed`-modifier.

Closes #61

## De ontwerpkeuze

Spelers zijn breedtegebonden, elk 1fr, hoogte volgt uit 16:9 — bij contrapunctus
~423×238 per speler tegen ~521×293 voor één enkele speler op `width: 60%`, dus
ongeveer 80% van de hoogte. Even hoog kan niet zonder de slidebreedte te
overschrijden, en op deze slide is de speler een luisterobject, geen kijkobject:
gelijktijdigheid is het punt.

`contrapunctus` heeft geen thema-CSS nodig, en dat is nagerekend in plaats van
ingeschat: het oude bijschrift pikte vijf eigenschappen op uit dat thema (mono,
`--step--1`, letterspacing, uppercase, `--color-text-quiet`), en `.duet-label`
zet in `layouts-base` exact diezelfde vijf uit dezelfde tokens. De rand rond de
speler komt uit `CourseVideoInline` via `--color-rule`, dat contrapunctus
definieert.

## Een stille breuk die net op tijd gevonden is

`check-coverage.mjs` telde alleen `<CourseVideo…>`-tags in de slidebody. Een
layout die video-id's naar de frontmatter verhuist, maakt die id's dus onzichtbaar
voor de teller — `perotin` stond alleen op deze slide en de dekking van
meerstemmigheid was stilletjes van 8/8 naar 7/8 gezakt, zonder buildfout.

Het script is uitgebreid en dat feit staat nu in `slides/README.md`. `check:slides`
geeft na deze PR nog steeds alle 5 decks volledig, exit 0.

## Controle

- `npx astro check` → 0 errors, 0 warnings, 0 hints
- `npm run build` → exit 0, alle 5 decks
- `npm run check:slides` → onveranderd, alle 5 volledig, exit 0
- Diffvorm: 6 bestanden, working tree leeg.

### Render-check: gedeeltelijk

Geen scherm. Uit de bundel: de layout is gecompileerd met al zijn scoped klassen
(`slidev-layout duet`, `duet--headed`, `duet-header`, `duet-row`, `duet-panel`,
`duet-label`), de headerslot krijgt de `h2` werkelijk doorgegeven, alle zes de
CSS-regels gebruiken uitsluitend tokens, **nul** `resolveComponent(` en
`CourseVideoInline` wordt statisch geïmporteerd, en beide video-id's resolven in
de meegebundelde `videos.generated.json`. Geen waarschuwingen in de buildlog.

Niet vastgesteld: of 423×238 per speler achterin een klas groot genoeg is, of de
labels onder de spelers de juiste plek zijn (boven is één regel CSS), en of de
notenbalk van contrapunctus boven twee zwarte kaders rustig oogt.

## Skill

§5 beloofde dat een eigen layout een eigen chunk krijgt. Dat klopt niet als de
layout maar op één slide staat: Rollup inlinet hem dan in de md-chunk van die
slide. Het bewijs is er wel, alleen niet in een bestand met die naam — de
formulering is aangepast, want anders concludeert de volgende worker ten onrechte
dat zijn layout niet gevonden is.
